### PR TITLE
Add test checks all pods are running

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -1,9 +1,15 @@
 package common
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/giantswarm/clustertest"
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/client"
+	"github.com/giantswarm/clustertest/pkg/wait"
+	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,4 +39,51 @@ func Run() {
 	It("should be able to connect to WC cluster", func() {
 		Expect(wcClient.CheckConnection()).To(Succeed())
 	})
+
+	It("has all of it's pods in the Running state", func() {
+		Eventually(Consistent(checkPodSuccessfulPhase(wcClient), 10, time.Second)).
+			WithTimeout(wait.DefaultTimeout).
+			WithPolling(wait.DefaultInterval).
+			Should(Succeed())
+	})
+}
+
+func Consistent(action func() error, attempts int, pollInterval time.Duration) func() error {
+	return func() error {
+		ticker := time.NewTicker(pollInterval)
+		for range ticker.C {
+			if attempts <= 0 {
+				ticker.Stop()
+				break
+			}
+
+			err := action()
+			if err != nil {
+				return err
+			}
+
+			attempts--
+		}
+
+		return nil
+	}
+}
+
+func checkPodSuccessfulPhase(wcClient *client.Client) func() error {
+	return func() error {
+		podList := &corev1.PodList{}
+		err := wcClient.List(context.Background(), podList)
+		if err != nil {
+			return err
+		}
+
+		for _, pod := range podList.Items {
+			phase := pod.Status.Phase
+			if phase != corev1.PodRunning && phase != corev1.PodSucceeded {
+				return fmt.Errorf("pod %s/%s in %s phase", pod.Namespace, pod.Name, phase)
+			}
+		}
+
+		return nil
+	}
 }


### PR DESCRIPTION
To do this we need to check that a condition is eventually consistent, i.e. an action **eventually** passes for a **period** of time. Ginkgo by default doesn't have a way to do this. We also need this because the pods could transition through states or new pods can show up and for just a moment all pods could end up Running or Successful, when just after a pod could fail or a new one could pop up. To solve this I added an exported function - `Consistent` - that will perform an action with specified number of attempts and polling period.