### PR TITLE
Schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Marked CAPV standard test suite as skipped until it can reliably run the tests.
 - Changed parameters for CAPVCD tests by applying latest schema changes.
+- Changed parameters for CAPVCD tests for `0.12.0` release.
 
 ## [1.3.0] - 2023-05-30
 

--- a/providers/capvcd/standard/test_data/cluster_values.yaml
+++ b/providers/capvcd/standard/test_data/cluster_values.yaml
@@ -1,45 +1,38 @@
-clusterName: "{{ .ClusterName }}"
-clusterDescription: "E2E Test cluster"
-organization: "{{ .Organization }}"
-
 baseDomain: test.gigantic.io
-kubernetesVersion: v1.22.9+vmware.1
-
-cloudDirector:
-  org: giantswarm
-  ovdc: vDC 73640
-  site: https://vmware.ikoula.com
-  ovdcNetwork: capvcd-192.168.52.0
-
-cloudProvider:
-  enableVirtualServiceSharedIP: false
-  oneArm:
-    enabled: true
-        
 controlPlane:
   catalog: giantswarm
   replicas: 3
   sizingPolicy: m1.large
   template: ubuntu-2004-kube-v1.22.9
-
 connectivity:
   network:
     loadBalancers:
       vipSubnet: "178.170.32.1/24"
-
-nodeClasses:
-  default:
-    catalog: giantswarm
-    sizingPolicy: m1.large
-    template: ubuntu-2004-kube-v1.22.9
+  proxy:
+    enabled: false
 nodePools:
   worker:
     class: default
     replicas: 2
-proxy:
-  enabled: false
-  secretName: ""
-userContext:
-  secretRef:
-    secretName: vcd-credentials
-    useSecretRef: true
+providerSpecific:
+  org: giantswarm
+  ovdc: vDC 73640
+  site: https://vmware.ikoula.com
+  ovdcNetwork: capvcd-192.168.52.0
+  cloudProviderInterface:
+    enableVirtualServiceSharedIP: false
+    oneArm:
+      enabled: true
+  nodeClasses:
+    default:
+      catalog: giantswarm
+      sizingPolicy: m1.large
+      template: ubuntu-2004-kube-v1.22.9
+  userContext:
+    secretRef:
+      secretName: vcd-credentials
+metadata:
+  description: "E2E Test cluster"
+  organization: "{{ .Organization }}"
+internal:
+  kubernetesVersion: v1.22.9+vmware.1


### PR DESCRIPTION
### What this PR does

Applies schema changes that are introduced with `0.12.0`.

https://github.com/giantswarm/cluster-cloud-director/releases/tag/v0.12.0

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
