### PR TITLE
Support app versions in 'standup' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `standup` now supports specifying cluster app and default-apps app versions as arguments, defaulting to latest
+
 ## [1.5.0] - 2023-07-17
 
 ### Added

--- a/cmd/standup/main.go
+++ b/cmd/standup/main.go
@@ -28,11 +28,13 @@ var (
 		RunE:    run,
 	}
 
-	provider         string
-	kubeContext      string
-	clusterValues    string
-	defaultAppValues string
-	outputDirectory  string
+	provider          string
+	kubeContext       string
+	clusterValues     string
+	defaultAppValues  string
+	clusterVersion    string
+	defaultAppVersion string
+	outputDirectory   string
 
 	controlPlaneNodes int
 	workerNodes       int
@@ -47,6 +49,8 @@ func init() {
 	standupCmd.Flags().IntVar(&controlPlaneNodes, "control-plane-nodes", 1, "The number of control plane nodes to wait for being ready")
 	standupCmd.Flags().IntVar(&workerNodes, "worker-nodes", 1, "The number of worker nodes to wait for being ready")
 	standupCmd.Flags().StringVar(&outputDirectory, "output", "./", "The directory to store the results.json and kubeconfig in")
+	standupCmd.Flags().StringVar(&clusterVersion, "cluster-version", "latest", "The version of the cluster app to install")
+	standupCmd.Flags().StringVar(&defaultAppVersion, "default-apps-version", "latest", "The version of the default-apps app to install")
 
 	standupCmd.MarkFlagRequired("provider")
 	standupCmd.MarkFlagRequired("context")
@@ -77,6 +81,7 @@ func run(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Standing up cluster...\n\nProvider:\t\t%s\nCluster Name:\t\t%s\nOrg Name:\t\t%s\nResults Directory:\t%s\n\n", provider, clusterName, orgName, outputDirectory)
 
 	cluster := application.NewClusterApp(clusterName, provider).
+		WithAppVersions(clusterVersion, defaultAppVersion).
 		WithOrg(organization.New(orgName)).
 		WithAppValuesFile(path.Clean(clusterValues), path.Clean(defaultAppValues))
 


### PR DESCRIPTION
### What this PR does

Allows setting the cluster and default-app app versions when using `standup` to create a test cluster

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

Skipping E2E tests as no changes to tests made