### PR TITLE
Abstract provider-specific Cluster App creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Abstract away the cluster app creation to a provider-specific function to handle provider specific requirements (such as VSphere credentials as extra config)
+
 ## [1.6.0] - 2023-07-20
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/giantswarm/clustertest v0.0.16
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
+	github.com/spf13/cobra v1.6.1
 	k8s.io/api v0.26.3
 	sigs.k8s.io/controller-runtime v0.14.5
 )
@@ -117,7 +118,6 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/providers/capa/cluster.go
+++ b/providers/capa/cluster.go
@@ -1,0 +1,22 @@
+package capa
+
+import (
+	"path"
+
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/organization"
+	"github.com/giantswarm/clustertest/pkg/utils"
+)
+
+func NewClusterApp(clusterName string, orgName string, clusterValuesFile string, defaultAppsValuesFile string) *application.Cluster {
+	if clusterName == "" {
+		clusterName = utils.GenerateRandomName("t")
+	}
+	if orgName == "" {
+		orgName = utils.GenerateRandomName("t")
+	}
+
+	return application.NewClusterApp(clusterName, application.ProviderAWS).
+		WithOrg(organization.New(orgName)).
+		WithAppValuesFile(path.Clean(clusterValuesFile), path.Clean(defaultAppsValuesFile))
+}

--- a/providers/capa/standard/capa_suite_test.go
+++ b/providers/capa/standard/capa_suite_test.go
@@ -2,7 +2,6 @@ package standard
 
 import (
 	"context"
-	"path"
 	"testing"
 	"time"
 
@@ -13,10 +12,10 @@ import (
 	"github.com/giantswarm/clustertest"
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/logger"
-	"github.com/giantswarm/clustertest/pkg/utils"
 	"github.com/giantswarm/clustertest/pkg/wait"
 
 	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/providers/capa"
 )
 
 const KubeContext = "capa"
@@ -58,8 +57,7 @@ func setUpWorkloadCluster() *application.Cluster {
 }
 
 func createCluster() *application.Cluster {
-	cluster = application.NewClusterApp(utils.GenerateRandomName("t"), application.ProviderAWS).
-		WithAppValuesFile(path.Clean("./test_data/cluster_values.yaml"), path.Clean("./test_data/default-apps_values.yaml"))
+	cluster = capa.NewClusterApp("", "", "./test_data/cluster_values.yaml", "./test_data/default-apps_values.yaml")
 	logger.Log("Workload cluster name: %s", cluster.Name)
 
 	applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 20*time.Minute)

--- a/providers/capv/cluster.go
+++ b/providers/capv/cluster.go
@@ -1,0 +1,45 @@
+package capv
+
+import (
+	"path"
+
+	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
+
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/organization"
+	"github.com/giantswarm/clustertest/pkg/utils"
+)
+
+const (
+	RegCredSecretName          = "container-registries-configuration"
+	RegCredSecretNamespace     = "default"
+	VSphereCredSecretName      = "vsphere-credentials"
+	VSphereCredSecretNamespace = "org-giantswarm"
+)
+
+func NewClusterApp(clusterName string, orgName string, clusterValuesFile string, defaultAppsValuesFile string) *application.Cluster {
+	if clusterName == "" {
+		clusterName = utils.GenerateRandomName("t")
+	}
+	if orgName == "" {
+		orgName = utils.GenerateRandomName("t")
+	}
+
+	return application.NewClusterApp(clusterName, application.ProviderVSphere).
+		WithOrg(organization.New(orgName)).
+		WithAppValuesFile(path.Clean(clusterValuesFile), path.Clean(defaultAppsValuesFile)).
+		WithExtraConfigs([]applicationv1alpha1.AppExtraConfig{
+			{
+				Kind:      "secret",
+				Name:      RegCredSecretName,
+				Namespace: RegCredSecretNamespace,
+				Priority:  25,
+			},
+			{
+				Kind:      "secret",
+				Name:      VSphereCredSecretName,
+				Namespace: VSphereCredSecretNamespace,
+				Priority:  25,
+			},
+		})
+}

--- a/providers/capv/standard/capv_suite_test.go
+++ b/providers/capv/standard/capv_suite_test.go
@@ -2,7 +2,6 @@ package standard
 
 import (
 	"context"
-	"path"
 	"testing"
 	"time"
 
@@ -11,13 +10,11 @@ import (
 
 	cr "sigs.k8s.io/controller-runtime/pkg/client"
 
-	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/providers/capv"
 	"github.com/giantswarm/clustertest"
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/logger"
-	"github.com/giantswarm/clustertest/pkg/organization"
-	"github.com/giantswarm/clustertest/pkg/utils"
 	"github.com/giantswarm/clustertest/pkg/wait"
 )
 
@@ -64,18 +61,7 @@ func setUpWorkloadCluster() *application.Cluster {
 }
 
 func createCluster() *application.Cluster {
-	cluster = application.NewClusterApp(utils.GenerateRandomName("t"), application.ProviderVSphere).
-		WithOrg(organization.New(defaultNamespace)). // Uses the `giantswarm` org (and namespace) as it requires a credentials secret to exist already
-		WithAppValuesFile(path.Clean("./test_data/cluster_values.yaml"), path.Clean("./test_data/default-apps_values.yaml")).
-		WithUserConfigSecret("vsphere-credentials").
-		WithExtraConfigs([]applicationv1alpha1.AppExtraConfig{
-			{
-				Kind:      "secret",
-				Name:      RegcredSecretName,
-				Namespace: defaultNamespace,
-				Priority:  25,
-			},
-		})
+	cluster = capv.NewClusterApp("", "", "./test_data/cluster_values.yaml", "./test_data/default-apps_values.yaml")
 
 	logger.Log("Workload cluster name: %s", cluster.Name)
 

--- a/providers/capvcd/cluster.go
+++ b/providers/capvcd/cluster.go
@@ -1,0 +1,45 @@
+package capvcd
+
+import (
+	"path"
+
+	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
+
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/organization"
+	"github.com/giantswarm/clustertest/pkg/utils"
+)
+
+const (
+	RegCredSecretName      = "container-registries-configuration"
+	RegCredSecretNamespace = "default"
+	VCDCredSecretName      = "vcd-credentials"
+	VCDCredSecretNamespace = "org-giantswarm"
+)
+
+func NewClusterApp(clusterName string, orgName string, clusterValuesFile string, defaultAppsValuesFile string) *application.Cluster {
+	if clusterName == "" {
+		clusterName = utils.GenerateRandomName("t")
+	}
+	if orgName == "" {
+		orgName = utils.GenerateRandomName("t")
+	}
+
+	return application.NewClusterApp(clusterName, application.ProviderCloudDirector).
+		WithOrg(organization.New(orgName)).
+		WithAppValuesFile(path.Clean(clusterValuesFile), path.Clean(defaultAppsValuesFile)).
+		WithExtraConfigs([]applicationv1alpha1.AppExtraConfig{
+			{
+				Kind:      "secret",
+				Name:      RegCredSecretName,
+				Namespace: RegCredSecretNamespace,
+				Priority:  25,
+			},
+			{
+				Kind:      "secret",
+				Name:      VCDCredSecretName,
+				Namespace: VCDCredSecretNamespace,
+				Priority:  25,
+			},
+		})
+}

--- a/providers/capvcd/standard/capvcd_suite_test.go
+++ b/providers/capvcd/standard/capvcd_suite_test.go
@@ -2,7 +2,6 @@ package standard
 
 import (
 	"context"
-	"path"
 	"testing"
 	"time"
 
@@ -14,11 +13,10 @@ import (
 	"github.com/giantswarm/clustertest"
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/logger"
-	"github.com/giantswarm/clustertest/pkg/organization"
-	"github.com/giantswarm/clustertest/pkg/utils"
 	"github.com/giantswarm/clustertest/pkg/wait"
 
 	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/providers/capvcd"
 )
 
 const KubeContext = "capvcd"
@@ -59,10 +57,7 @@ func setUpWorkloadCluster() *application.Cluster {
 }
 
 func createCluster() *application.Cluster {
-	cluster = application.NewClusterApp(utils.GenerateRandomName("t"), application.ProviderCloudDirector).
-		WithOrg(organization.New("giantswarm")). // Uses the `giantswarm` org (and namespace) as it requires a credentials secret to exist already
-		WithAppValuesFile(path.Clean("./test_data/cluster_values.yaml"), path.Clean("./test_data/default-apps_values.yaml"))
-
+	cluster = capvcd.NewClusterApp("", "", "./test_data/cluster_values.yaml", "./test_data/default-apps_values.yaml")
 	logger.Log("Workload cluster name: %s", cluster.Name)
 
 	applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 20*time.Minute)

--- a/providers/capz/cluster.go
+++ b/providers/capz/cluster.go
@@ -1,0 +1,22 @@
+package capz
+
+import (
+	"path"
+
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/organization"
+	"github.com/giantswarm/clustertest/pkg/utils"
+)
+
+func NewClusterApp(clusterName string, orgName string, clusterValuesFile string, defaultAppsValuesFile string) *application.Cluster {
+	if clusterName == "" {
+		clusterName = utils.GenerateRandomName("t")
+	}
+	if orgName == "" {
+		orgName = utils.GenerateRandomName("t")
+	}
+
+	return application.NewClusterApp(clusterName, application.ProviderAzure).
+		WithOrg(organization.New(orgName)).
+		WithAppValuesFile(path.Clean(clusterValuesFile), path.Clean(defaultAppsValuesFile))
+}

--- a/providers/capz/standard/capz_suite_test.go
+++ b/providers/capz/standard/capz_suite_test.go
@@ -2,7 +2,6 @@ package standard
 
 import (
 	"context"
-	"path"
 	"testing"
 	"time"
 
@@ -14,10 +13,10 @@ import (
 	"github.com/giantswarm/clustertest"
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/logger"
-	"github.com/giantswarm/clustertest/pkg/utils"
 	"github.com/giantswarm/clustertest/pkg/wait"
 
 	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/providers/capz"
 )
 
 const KubeContext = "capz"
@@ -58,9 +57,7 @@ func setUpWorkloadCluster() *application.Cluster {
 }
 
 func createCluster() *application.Cluster {
-	cluster = application.NewClusterApp(utils.GenerateRandomName("t"), application.ProviderAzure).
-		WithAppValuesFile(path.Clean("./test_data/cluster_values.yaml"), path.Clean("./test_data/default-apps_values.yaml"))
-
+	cluster = capz.NewClusterApp("", "", "./test_data/cluster_values.yaml", "./test_data/default-apps_values.yaml")
 	logger.Log("Workload cluster name: %s", cluster.Name)
 
 	applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 20*time.Minute)


### PR DESCRIPTION
### What this PR does

- Pulls out the creation of the `Cluster` app to a provider-specific `NewClusterApp` function that abstracts away any cluster-specific logic.
- Fixed the CAPV and CAPVCD clusters to specify the credentials secrets as extra configs that can be referenced cross-namespace. This allows us to use test Orgs with these providers too like CAPA and CAPZ.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
