### PR TITLE
Added Upgrade test suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped clustertest to `v0.1.1` to fix `GITHUB_TOKEN` issue
 
+### Added
+
+- Upgrade cluster tests
+
 ## [1.7.0] - 2023-07-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ Running with Docker:
 docker run --rm -it -v /path/to/kubeconfig.yaml:/kubeconfig.yaml -e E2E_KUBECONFIG=/kubeconfig.yaml quay.io/giantswarm/cluster-test-suites ./
 ```
 
+## ⬆️ Upgrade Tests
+
+Each of the providers have a test suite called `upgrade` that is designed to first install a cluster using the latest released version of both the cluster App and the default-apps App. It then upgrades that cluster to whatever currently needs testing.
+
+There are a few things to be aware about these tests:
+
+* These test suites only run if a `E2E_OVERRIDE_VERSIONS` environment variable is set, indicating the versions to upgrade the Apps to.
+* The initial workload cluster created uses whatever the latest released version on GitHub is, this is not currently configurable.
+* These test suites use [Ginkgo Ordered Containers](https://onsi.github.io/ginkgo/#ordered-containers) to ensure certain tests specs are run before and after the upgrade process as required.
+
 ## ➕ Adding Tests
 
 > See the Ginkgo docs for specifics on how to write tests: https://onsi.github.io/ginkgo/#writing-specs

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -1,0 +1,113 @@
+package upgrade
+
+import (
+	"context"
+	"time"
+
+	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/clustertest"
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/wait"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	Framework *clustertest.Framework
+	Cluster   *application.Cluster
+)
+
+func Run() {
+	Context("upgrade", func() {
+		ctx := context.Background()
+
+		It("has all the control-plane nodes running", func() {
+			values := &application.ClusterValues{}
+			err := Framework.MC().GetHelmValues(Cluster.Name, Cluster.Namespace, values)
+			Expect(err).NotTo(HaveOccurred())
+
+			wcClient, err := Framework.WC(Cluster.Name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, values.ControlPlane), 12, 5*time.Second)).
+				WithTimeout(wait.DefaultTimeout).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+
+		It("has all the worker nodes running", func() {
+			values := &application.ClusterValues{}
+			err := Framework.MC().GetHelmValues(Cluster.Name, Cluster.Namespace, values)
+			Expect(err).NotTo(HaveOccurred())
+
+			wcClient, err := Framework.WC(Cluster.Name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(wait.Consistent(common.CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
+				WithTimeout(wait.DefaultTimeout).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+
+		It("should upgrade successfully", func() {
+			// Set app versions to `""` so that it makes use of the overrides set in the `E2E_OVERRIDE_VERSIONS` environment var
+			Cluster = Cluster.WithAppVersions("", "")
+			applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 20*time.Minute)
+			defer cancelApplyCtx()
+
+			_, err := Framework.ApplyCluster(applyCtx, Cluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			clusterApp, _, defaultAppsApp, _, _ := Cluster.Build()
+
+			Eventually(
+				wait.IsAppVersion(ctx, Framework.MC(), defaultAppsApp.Name, defaultAppsApp.Namespace, defaultAppsApp.Spec.Version),
+				10*time.Minute, 5*time.Second,
+			).Should(BeTrue())
+
+			Eventually(
+				wait.IsAppStatus(ctx, Framework.MC(), defaultAppsApp.Name, defaultAppsApp.Namespace, "deployed"),
+				10*time.Minute, 5*time.Second,
+			).Should(BeTrue())
+
+			Eventually(
+				wait.IsAppVersion(ctx, Framework.MC(), clusterApp.Name, clusterApp.Namespace, clusterApp.Spec.Version),
+				10*time.Minute, 5*time.Second,
+			).Should(BeTrue())
+
+			Eventually(
+				wait.IsAppStatus(ctx, Framework.MC(), clusterApp.Name, clusterApp.Namespace, "deployed"),
+				10*time.Minute, 5*time.Second,
+			).Should(BeTrue())
+		})
+
+		It("has all the control-plane nodes running", func() {
+			values := &application.ClusterValues{}
+			err := Framework.MC().GetHelmValues(Cluster.Name, Cluster.Namespace, values)
+			Expect(err).NotTo(HaveOccurred())
+
+			wcClient, err := Framework.WC(Cluster.Name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, values.ControlPlane), 12, 5*time.Second)).
+				WithTimeout(wait.DefaultTimeout).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+
+		It("has all the worker nodes running", func() {
+			values := &application.ClusterValues{}
+			err := Framework.MC().GetHelmValues(Cluster.Name, Cluster.Namespace, values)
+			Expect(err).NotTo(HaveOccurred())
+
+			wcClient, err := Framework.WC(Cluster.Name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(wait.Consistent(common.CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
+				WithTimeout(wait.DefaultTimeout).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+	})
+}

--- a/providers/capa/upgrade/capa_suite_test.go
+++ b/providers/capa/upgrade/capa_suite_test.go
@@ -1,0 +1,89 @@
+package upgrade
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/clustertest"
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/logger"
+	"github.com/giantswarm/clustertest/pkg/wait"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
+	"github.com/giantswarm/cluster-test-suites/providers/capa"
+)
+
+const KubeContext = "capa"
+
+var (
+	ctx       context.Context
+	framework *clustertest.Framework
+	cluster   *application.Cluster
+)
+
+func TestCAPAUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPA Upgrade Suite")
+}
+
+var _ = BeforeSuite(func() {
+	if os.Getenv("E2E_OVERRIDE_VERSIONS") == "" {
+		Skip("E2E_OVERRIDE_VERSIONS env var not set, skipping upgrade test")
+		return
+	}
+
+	ctx = context.Background()
+	logger.LogWriter = GinkgoWriter
+
+	var err error
+	framework, err = clustertest.New(KubeContext)
+	Expect(err).NotTo(HaveOccurred())
+
+	cluster = setUpWorkloadCluster()
+
+	common.Framework = framework
+	common.Cluster = cluster
+	upgrade.Framework = framework
+	upgrade.Cluster = cluster
+})
+
+func setUpWorkloadCluster() *application.Cluster {
+	cluster, err := framework.LoadCluster()
+	Expect(err).NotTo(HaveOccurred())
+	if cluster != nil {
+		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.Namespace)
+		return cluster
+	}
+
+	return createCluster()
+}
+
+func createCluster() *application.Cluster {
+	cluster = capa.NewClusterApp("", "", "./test_data/cluster_values.yaml", "./test_data/default-apps_values.yaml").
+		WithAppVersions("latest", "latest")
+	logger.Log("Workload cluster name: %s", cluster.Name)
+
+	applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 20*time.Minute)
+	defer cancelApplyCtx()
+
+	client, err := framework.ApplyCluster(applyCtx, cluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	Eventually(
+		wait.AreNumNodesReady(ctx, client, 1, &cr.MatchingLabels{"node-role.kubernetes.io/control-plane": ""}),
+		20*time.Minute, 15*time.Second,
+	).Should(BeTrue())
+
+	DeferCleanup(func() {
+		Expect(framework.DeleteCluster(ctx, cluster)).To(Succeed())
+	})
+
+	return cluster
+}

--- a/providers/capa/upgrade/capa_suite_test.go
+++ b/providers/capa/upgrade/capa_suite_test.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ func TestCAPAUpgrade(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	if os.Getenv("E2E_OVERRIDE_VERSIONS") == "" {
+	if strings.TrimSpace(os.Getenv("E2E_OVERRIDE_VERSIONS")) == "" {
 		Skip("E2E_OVERRIDE_VERSIONS env var not set, skipping upgrade test")
 		return
 	}

--- a/providers/capa/upgrade/capa_test.go
+++ b/providers/capa/upgrade/capa_test.go
@@ -1,0 +1,17 @@
+package upgrade
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
+)
+
+var _ = Describe("Basic upgrade test", Ordered, func() {
+	upgrade.Run()
+
+	// Finally run the common tests after upgrade is completed
+	common.Run(&common.TestConfig{
+		BastionSupported: true,
+	})
+})

--- a/providers/capa/upgrade/test_data/cluster_values.yaml
+++ b/providers/capa/upgrade/test_data/cluster_values.yaml
@@ -1,0 +1,17 @@
+metadata:
+  name: "{{ .ClusterName }}"
+  description: "E2E Test cluster"
+  organization: "{{ .Organization }}"
+
+controlPlane:
+  replicas: 3
+nodePools:
+  pool0:
+    instanceType: m5.xlarge
+    maxSize: 10
+    minSize: 3
+    rootVolumeSizeGB: 300
+connectivity:
+  availabilityZoneUsageLimit: 3
+  bastion:
+    enabled: true

--- a/providers/capa/upgrade/test_data/default-apps_values.yaml
+++ b/providers/capa/upgrade/test_data/default-apps_values.yaml
@@ -1,0 +1,2 @@
+clusterName: "{{ .ClusterName }}"
+organization: "{{ .Organization }}"

--- a/providers/capv/upgrade/capv_suite_test.go
+++ b/providers/capv/upgrade/capv_suite_test.go
@@ -1,0 +1,89 @@
+package upgrade
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/clustertest"
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/logger"
+	"github.com/giantswarm/clustertest/pkg/wait"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
+	"github.com/giantswarm/cluster-test-suites/providers/capv"
+)
+
+const KubeContext = "capv"
+
+var (
+	ctx       context.Context
+	framework *clustertest.Framework
+	cluster   *application.Cluster
+)
+
+func TestCAPVUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPV Upgrade Suite")
+}
+
+var _ = BeforeSuite(func() {
+	if os.Getenv("E2E_OVERRIDE_VERSIONS") == "" {
+		Skip("E2E_OVERRIDE_VERSIONS env var not set, skipping upgrade test")
+		return
+	}
+
+	ctx = context.Background()
+	logger.LogWriter = GinkgoWriter
+
+	var err error
+	framework, err = clustertest.New(KubeContext)
+	Expect(err).NotTo(HaveOccurred())
+
+	cluster = setUpWorkloadCluster()
+
+	common.Framework = framework
+	common.Cluster = cluster
+	upgrade.Framework = framework
+	upgrade.Cluster = cluster
+})
+
+func setUpWorkloadCluster() *application.Cluster {
+	cluster, err := framework.LoadCluster()
+	Expect(err).NotTo(HaveOccurred())
+	if cluster != nil {
+		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.Namespace)
+		return cluster
+	}
+
+	return createCluster()
+}
+
+func createCluster() *application.Cluster {
+	cluster = capv.NewClusterApp("", "", "./test_data/cluster_values.yaml", "./test_data/default-apps_values.yaml").
+		WithAppVersions("latest", "latest")
+	logger.Log("Workload cluster name: %s", cluster.Name)
+
+	applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 20*time.Minute)
+	defer cancelApplyCtx()
+
+	client, err := framework.ApplyCluster(applyCtx, cluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	Eventually(
+		wait.AreNumNodesReady(ctx, client, 1, &cr.MatchingLabels{"node-role.kubernetes.io/control-plane": ""}),
+		20*time.Minute, 15*time.Second,
+	).Should(BeTrue())
+
+	DeferCleanup(func() {
+		Expect(framework.DeleteCluster(ctx, cluster)).To(Succeed())
+	})
+
+	return cluster
+}

--- a/providers/capv/upgrade/capv_suite_test.go
+++ b/providers/capv/upgrade/capv_suite_test.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ func TestCAPVUpgrade(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	if os.Getenv("E2E_OVERRIDE_VERSIONS") == "" {
+	if strings.TrimSpace(os.Getenv("E2E_OVERRIDE_VERSIONS")) == "" {
 		Skip("E2E_OVERRIDE_VERSIONS env var not set, skipping upgrade test")
 		return
 	}

--- a/providers/capv/upgrade/capv_test.go
+++ b/providers/capv/upgrade/capv_test.go
@@ -1,0 +1,17 @@
+package upgrade
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
+)
+
+var _ = Describe("Basic upgrade test", Ordered, func() {
+	upgrade.Run()
+
+	// Finally run the common tests after upgrade is completed
+	common.Run(&common.TestConfig{
+		BastionSupported: true,
+	})
+})

--- a/providers/capv/upgrade/test_data/cluster_values.yaml
+++ b/providers/capv/upgrade/test_data/cluster_values.yaml
@@ -1,0 +1,54 @@
+clusterDescription: "E2E Test cluster"
+organization: "{{ .Organization }}"
+
+baseDomain: test.gigantic.io
+cluster:
+  kubernetesVersion: "v1.24.11"
+
+controlPlane:
+  replicas: 1
+  catalog: "giantswarm"
+  image:
+    repository: registry.k8s.io
+  machineTemplate:
+    template: ubuntu-2004-kube-v1.24.11
+    cloneMode: "linkedClone"
+    diskGiB: 50
+    numCPUs: 4
+    memoryMiB: 8096
+    resourcePool: "grasshopper"
+    network:
+      devices:
+      - networkName: 'grasshopper-capv'
+        dhcp4: true
+
+connectivity:
+  bastion:
+    enabled: true
+  network:
+    allowAllEgress: true
+    controlPlaneEndpoint:
+      host: ""  # [string] Manually select an IP for kube API. "" for auto selection from the ipPoolName pool.
+      port: 6443
+      ipPoolName: "wc-cp-ips"  # [string] Ip for control plane will be drawn from this GlobalInClusterIPPool (for gcapeverde it's 10.10.222.232 - 10.10.222.238 inclusive)
+    loadBalancers:
+      cidrBlocks:
+      - "10.10.222.239/32"
+
+nodeClasses:
+  default:
+    template: ubuntu-2004-kube-v1.24.11
+    cloneMode: "linkedClone"
+    diskGiB: 50
+    numCPUs: 6
+    memoryMiB: 16896
+    resourcePool: "grasshopper"
+    network:
+      devices:
+      - networkName: 'grasshopper-capv'
+        dhcp4: true
+
+nodePools:
+  worker:
+    class: "default"
+    replicas: 2

--- a/providers/capv/upgrade/test_data/default-apps_values.yaml
+++ b/providers/capv/upgrade/test_data/default-apps_values.yaml
@@ -1,0 +1,2 @@
+clusterName: "{{ .ClusterName }}"
+organization: "{{ .Organization }}"

--- a/providers/capvcd/upgrade/capvcd_suite_test.go
+++ b/providers/capvcd/upgrade/capvcd_suite_test.go
@@ -1,0 +1,89 @@
+package upgrade
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/clustertest"
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/logger"
+	"github.com/giantswarm/clustertest/pkg/wait"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
+	"github.com/giantswarm/cluster-test-suites/providers/capvcd"
+)
+
+const KubeContext = "capvcd"
+
+var (
+	ctx       context.Context
+	framework *clustertest.Framework
+	cluster   *application.Cluster
+)
+
+func TestCAPVCDUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPVCD Upgrade Suite")
+}
+
+var _ = BeforeSuite(func() {
+	if os.Getenv("E2E_OVERRIDE_VERSIONS") == "" {
+		Skip("E2E_OVERRIDE_VERSIONS env var not set, skipping upgrade test")
+		return
+	}
+
+	ctx = context.Background()
+	logger.LogWriter = GinkgoWriter
+
+	var err error
+	framework, err = clustertest.New(KubeContext)
+	Expect(err).NotTo(HaveOccurred())
+
+	cluster = setUpWorkloadCluster()
+
+	common.Framework = framework
+	common.Cluster = cluster
+	upgrade.Framework = framework
+	upgrade.Cluster = cluster
+})
+
+func setUpWorkloadCluster() *application.Cluster {
+	cluster, err := framework.LoadCluster()
+	Expect(err).NotTo(HaveOccurred())
+	if cluster != nil {
+		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.Namespace)
+		return cluster
+	}
+
+	return createCluster()
+}
+
+func createCluster() *application.Cluster {
+	cluster = capvcd.NewClusterApp("", "", "./test_data/cluster_values.yaml", "./test_data/default-apps_values.yaml").
+		WithAppVersions("latest", "latest")
+	logger.Log("Workload cluster name: %s", cluster.Name)
+
+	applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 20*time.Minute)
+	defer cancelApplyCtx()
+
+	client, err := framework.ApplyCluster(applyCtx, cluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	Eventually(
+		wait.AreNumNodesReady(ctx, client, 1, &cr.MatchingLabels{"node-role.kubernetes.io/control-plane": ""}),
+		20*time.Minute, 15*time.Second,
+	).Should(BeTrue())
+
+	DeferCleanup(func() {
+		Expect(framework.DeleteCluster(ctx, cluster)).To(Succeed())
+	})
+
+	return cluster
+}

--- a/providers/capvcd/upgrade/capvcd_suite_test.go
+++ b/providers/capvcd/upgrade/capvcd_suite_test.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ func TestCAPVCDUpgrade(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	if os.Getenv("E2E_OVERRIDE_VERSIONS") == "" {
+	if strings.TrimSpace(os.Getenv("E2E_OVERRIDE_VERSIONS")) == "" {
 		Skip("E2E_OVERRIDE_VERSIONS env var not set, skipping upgrade test")
 		return
 	}

--- a/providers/capvcd/upgrade/capvcd_test.go
+++ b/providers/capvcd/upgrade/capvcd_test.go
@@ -1,0 +1,17 @@
+package upgrade
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
+)
+
+var _ = Describe("Basic upgrade test", Ordered, func() {
+	upgrade.Run()
+
+	// Finally run the common tests after upgrade is completed
+	common.Run(&common.TestConfig{
+		BastionSupported: true,
+	})
+})

--- a/providers/capvcd/upgrade/test_data/cluster_values.yaml
+++ b/providers/capvcd/upgrade/test_data/cluster_values.yaml
@@ -1,0 +1,40 @@
+baseDomain: test.gigantic.io
+controlPlane:
+  catalog: giantswarm
+  replicas: 3
+  sizingPolicy: m1.large
+  template: ubuntu-2004-kube-v1.22.9
+connectivity:
+  bastion:
+    enabled: true
+  network:
+    loadBalancers:
+      vipSubnet: "178.170.32.1/24"
+  proxy:
+    enabled: false
+nodePools:
+  worker:
+    class: default
+    replicas: 2
+providerSpecific:
+  org: giantswarm
+  ovdc: vDC 73640
+  site: https://vmware.ikoula.com
+  ovdcNetwork: capvcd-192.168.52.0
+  cloudProviderInterface:
+    enableVirtualServiceSharedIP: false
+    oneArm:
+      enabled: true
+  nodeClasses:
+    default:
+      catalog: giantswarm
+      sizingPolicy: m1.large
+      template: ubuntu-2004-kube-v1.22.9
+  userContext:
+    secretRef:
+      secretName: vcd-credentials
+metadata:
+  description: "E2E Test cluster"
+  organization: "{{ .Organization }}"
+internal:
+  kubernetesVersion: v1.22.9+vmware.1

--- a/providers/capvcd/upgrade/test_data/default-apps_values.yaml
+++ b/providers/capvcd/upgrade/test_data/default-apps_values.yaml
@@ -1,0 +1,2 @@
+clusterName: "{{ .ClusterName }}"
+organization: "{{ .Organization }}"

--- a/providers/capz/upgrade/capz_suite_test.go
+++ b/providers/capz/upgrade/capz_suite_test.go
@@ -1,0 +1,89 @@
+package upgrade
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/clustertest"
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/logger"
+	"github.com/giantswarm/clustertest/pkg/wait"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
+	"github.com/giantswarm/cluster-test-suites/providers/capz"
+)
+
+const KubeContext = "capz"
+
+var (
+	ctx       context.Context
+	framework *clustertest.Framework
+	cluster   *application.Cluster
+)
+
+func TestCAPZUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPZ Upgrade Suite")
+}
+
+var _ = BeforeSuite(func() {
+	if os.Getenv("E2E_OVERRIDE_VERSIONS") == "" {
+		Skip("E2E_OVERRIDE_VERSIONS env var not set, skipping upgrade test")
+		return
+	}
+
+	ctx = context.Background()
+	logger.LogWriter = GinkgoWriter
+
+	var err error
+	framework, err = clustertest.New(KubeContext)
+	Expect(err).NotTo(HaveOccurred())
+
+	cluster = setUpWorkloadCluster()
+
+	common.Framework = framework
+	common.Cluster = cluster
+	upgrade.Framework = framework
+	upgrade.Cluster = cluster
+})
+
+func setUpWorkloadCluster() *application.Cluster {
+	cluster, err := framework.LoadCluster()
+	Expect(err).NotTo(HaveOccurred())
+	if cluster != nil {
+		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.Namespace)
+		return cluster
+	}
+
+	return createCluster()
+}
+
+func createCluster() *application.Cluster {
+	cluster = capz.NewClusterApp("", "", "./test_data/cluster_values.yaml", "./test_data/default-apps_values.yaml").
+		WithAppVersions("latest", "latest")
+	logger.Log("Workload cluster name: %s", cluster.Name)
+
+	applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 20*time.Minute)
+	defer cancelApplyCtx()
+
+	client, err := framework.ApplyCluster(applyCtx, cluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	Eventually(
+		wait.AreNumNodesReady(ctx, client, 1, &cr.MatchingLabels{"node-role.kubernetes.io/control-plane": ""}),
+		20*time.Minute, 15*time.Second,
+	).Should(BeTrue())
+
+	DeferCleanup(func() {
+		Expect(framework.DeleteCluster(ctx, cluster)).To(Succeed())
+	})
+
+	return cluster
+}

--- a/providers/capz/upgrade/capz_suite_test.go
+++ b/providers/capz/upgrade/capz_suite_test.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ func TestCAPZUpgrade(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	if os.Getenv("E2E_OVERRIDE_VERSIONS") == "" {
+	if strings.TrimSpace(os.Getenv("E2E_OVERRIDE_VERSIONS")) == "" {
 		Skip("E2E_OVERRIDE_VERSIONS env var not set, skipping upgrade test")
 		return
 	}

--- a/providers/capz/upgrade/capz_test.go
+++ b/providers/capz/upgrade/capz_test.go
@@ -1,0 +1,17 @@
+package upgrade
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
+)
+
+var _ = Describe("Basic upgrade test", Ordered, func() {
+	upgrade.Run()
+
+	// Finally run the common tests after upgrade is completed
+	common.Run(&common.TestConfig{
+		BastionSupported: true,
+	})
+})

--- a/providers/capz/upgrade/test_data/cluster_values.yaml
+++ b/providers/capz/upgrade/test_data/cluster_values.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: "{{ .ClusterName }}"
+  description: "E2E Test cluster"
+  organization: "{{ .Organization }}"
+providerSpecific:
+  location: "westeurope"
+  subscriptionId: 6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3
+nodePools:
+- name: md00
+  instanceType: Standard_D2s_v5
+  replicas: 3
+  rootVolumeSizeGB: 50
+connectivity:
+  bastion:
+    enabled: true

--- a/providers/capz/upgrade/test_data/default-apps_values.yaml
+++ b/providers/capz/upgrade/test_data/default-apps_values.yaml
@@ -1,0 +1,2 @@
+clusterName: "{{ .ClusterName }}"
+organization: "{{ .Organization }}"


### PR DESCRIPTION
### What this PR does

Adds upgrade test suites that will run from cluster/default-apps App PRs. These tests require the `E2E_OVERRIDE_VERSIONS` to be set so will be skipped when running against `cluster-test-suites`.

The upgrade test suite creates a workload cluster using the latest released versions then waits for the nodes to be in a ready state. It then performs the upgrade by modifying the `version` property of the App on the MC and waits for both the cluster App and the default-apps App to have the expected version deployed. Finally they check for the nodes being in a ready state again (in case the upgrade needs to roll nodes) and then runs the common test specs.

Fixes: https://github.com/giantswarm/roadmap/issues/2679

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
