### PR TITLE
Update CODEOWNERS in cluster-test-suites

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # Main / Shared
 * @giantswarm/team-tinkerers
-/common @giantswarm/team-clippy @giantswarm/team-phoenix @giantswarm/team-rocket
+/common @giantswarm/team-phoenix @giantswarm/team-rocket
 
 # Teams:
-/providers/capz @giantswarm/team-clippy
+/providers/capz @giantswarm/team-phoenix
 /providers/capa @giantswarm/team-phoenix
 /providers/capvcd @giantswarm/team-rocket
 /providers/capv @giantswarm/team-rocket


### PR DESCRIPTION
Since clippy no longer exists, the file was invalid.

Is it correct to assign CAPZ to phoenix?