### PR TITLE
Disable bastion tests for CAPV during upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add a PVC test.
 
+### Fixed
+
+- Bastion tests are disabled for CAPV.
+
 ## [1.8.0] - 2023-08-14
 
 ### Added

--- a/providers/capv/upgrade/capv_test.go
+++ b/providers/capv/upgrade/capv_test.go
@@ -12,6 +12,6 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 
 	// Finally run the common tests after upgrade is completed
 	common.Run(&common.TestConfig{
-		BastionSupported: true,
+		BastionSupported: false,
 	})
 })


### PR DESCRIPTION
We don't support bastion for CAPV and upgrade tests are failing because of this check now.

### What this PR does


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
