### PR TITLE
Refactor app tests so they log out progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bumped clustertest to `v0.2.0` to use custom app values.
+- Refactored default app tests so they can log out current state during iterations
 
 ## [1.9.0] - 2023-08-21
 

--- a/common/apps.go
+++ b/common/apps.go
@@ -1,87 +1,65 @@
 package common
 
 import (
-	"context"
 	"fmt"
+	"time"
 
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	"github.com/giantswarm/clustertest/pkg/logger"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/format"
-	"github.com/onsi/gomega/types"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
 
+const deployedStatus = "deployed"
+
 func runApps() {
 	Context("default apps", func() {
-		var customFormatterKey format.CustomFormatterKey
-		BeforeEach(func() {
-			customFormatterKey = format.RegisterCustomFormatter(func(value interface{}) (string, bool) {
-				app, ok := value.(v1alpha1.App)
-				if ok {
-					return fmt.Sprintf("App: %s/%s, Status: %s, Reason: %s", app.Namespace, app.Name, app.Status.Release.Status, app.Status.Release.Reason), true
-				}
-
-				return "", false
-			})
-		})
-
 		It("all default apps are deployed without issues", func() {
-			ctx := context.Background()
 
 			// We need to wait for default-apps to be deployed before we can check all apps.
 			defaultAppsAppName := fmt.Sprintf("%s-%s", state.GetCluster().Name, "default-apps")
-			Eventually(state.GetFramework().GetApp, "30s").WithContext(ctx).WithArguments(defaultAppsAppName, state.GetCluster().Organization.GetNamespace()).Should(HaveAppStatus("deployed"))
+			Eventually(func() error {
+				app, err := state.GetFramework().GetApp(state.GetContext(), defaultAppsAppName, state.GetCluster().Organization.GetNamespace())
+				if err != nil {
+					return err
+				}
+				return checkAppStatus(app)
+			}).
+				WithTimeout(30 * time.Second).
+				WithPolling(50 * time.Millisecond).
+				Should(Succeed())
 
-			managementClusterKubeClient := state.GetFramework().MC()
-			appList := &v1alpha1.AppList{}
-			err := managementClusterKubeClient.List(ctx, appList, ctrl.InNamespace(state.GetCluster().Organization.GetNamespace()), ctrl.MatchingLabels{"giantswarm.io/managed-by": defaultAppsAppName})
-			Expect(err).ShouldNot(HaveOccurred())
+			// Wait for all default-apps apps to be deployed
+			Eventually(func() error {
+				appList := &v1alpha1.AppList{}
+				err := state.GetFramework().MC().List(state.GetContext(), appList, ctrl.InNamespace(state.GetCluster().Organization.GetNamespace()), ctrl.MatchingLabels{"giantswarm.io/managed-by": defaultAppsAppName})
+				if err != nil {
+					return err
+				}
 
-			for _, app := range appList.Items {
-				Eventually(state.GetFramework().GetApp, "15m", "10s").WithContext(ctx).WithArguments(app.Name, app.Namespace).Should(HaveAppStatus("deployed"))
-			}
-		})
+				for _, app := range appList.Items {
+					if err := checkAppStatus(&app); err != nil {
+						return err
+					}
+				}
 
-		AfterEach(func() {
-			format.UnregisterCustomFormatter(customFormatterKey)
+				return nil
+			}).
+				WithTimeout(15 * time.Minute).
+				WithPolling(10 * time.Second).
+				Should(Succeed())
+
 		})
 	})
 }
 
-func HaveAppStatus(expected string) types.GomegaMatcher {
-	return &haveAppStatus{expected: expected}
-}
-
-type haveAppStatus struct {
-	expected string
-}
-
-func (m *haveAppStatus) Match(actual interface{}) (bool, error) {
-	if actual == nil {
-		return false, nil
+func checkAppStatus(app *v1alpha1.App) error {
+	if app.Status.Release.Status != deployedStatus {
+		logger.Log("App %s status is currently '%s'", app.Name, app.Status.Release.Status)
+		return fmt.Errorf("app %s status is '%s'", app.Name, app.Status.Release.Status)
 	}
-
-	actualApp, isApp := actual.(*v1alpha1.App)
-	if !isApp {
-		return false, fmt.Errorf("%#v is not an App", actual)
-	}
-
-	return Equal(actualApp.Status.Release.Status).Match(m.expected)
-}
-
-func (m *haveAppStatus) FailureMessage(actual interface{}) (message string) {
-	return format.Message(
-		actual,
-		fmt.Sprintf("to be an App with release status: %s", m.expected),
-	)
-}
-
-func (m *haveAppStatus) NegatedFailureMessage(actual interface{}) (message string) {
-	return format.Message(
-		actual,
-		fmt.Sprintf("not to be an App with release status: %s", m.expected),
-	)
+	return nil
 }

--- a/common/apps.go
+++ b/common/apps.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/clustertest/pkg/logger"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/cluster-test-suites/internal/state"
@@ -40,13 +41,14 @@ func runApps() {
 					return err
 				}
 
+				errs := []error{}
 				for _, app := range appList.Items {
 					if err := checkAppStatus(&app); err != nil {
-						return err
+						errs = append(errs, err)
 					}
 				}
 
-				return nil
+				return errors.NewAggregate(errs)
 			}).
 				WithTimeout(15 * time.Minute).
 				WithPolling(10 * time.Second).


### PR DESCRIPTION
### What this PR does

- Refactors the app test so that it can log out the progress as it waits for the eventual desired state.

I removed the custom report formatter as the log output should give the same level of information but without waiting for it to fail. I also haven't seen these formatters used for any other tests so seemed a bit odd just having them in place for this one. If you feel its still worth having it included let me know and I'll be happy to add it back.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
