### PR TITLE
Bump clustertest to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bumped clustertest to `v0.3.0` to be able to set the app `Organization`.
+
+### Changed
+
 - Bumped clustertest to `v0.2.0` to use custom app values.
 
 ## [1.9.0] - 2023-08-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bumped clustertest to `v0.3.0` to be able to set the app `Organization`.
-
-### Changed
-
 - Bumped clustertest to `v0.2.0` to use custom app values.
 
 ## [1.9.0] - 2023-08-21

--- a/cmd/standup/main.go
+++ b/cmd/standup/main.go
@@ -131,7 +131,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	defer kubeconfigFile.Close()
 
-	kubeconfig, err := framework.MC().GetClusterKubeConfig(ctx, cluster.Name, cluster.Namespace)
+	kubeconfig, err := framework.MC().GetClusterKubeConfig(ctx, cluster.Name, cluster.GetNamespace())
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func run(cmd *cobra.Command, args []string) error {
 		Provider:       string(provider),
 		ClusterName:    clusterName,
 		OrgName:        orgName,
-		Namespace:      cluster.Namespace,
+		Namespace:      cluster.GetNamespace(),
 		ClusterVersion: cluster.ClusterApp.Version,
 		KubeconfigPath: kubeconfigFile.Name(),
 	}

--- a/common/dns.go
+++ b/common/dns.go
@@ -6,12 +6,13 @@ import (
 	"net"
 	"time"
 
-	"github.com/giantswarm/cluster-test-suites/internal/state"
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/wait"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
 
 func runDNS(bastionSuppoted bool) {
@@ -34,7 +35,7 @@ func runDNS(bastionSuppoted bool) {
 		BeforeEach(func() {
 			values = &application.DefaultAppsValues{}
 			defaultAppsName := fmt.Sprintf("%s-default-apps", state.GetCluster().Name)
-			err := state.GetFramework().MC().GetHelmValues(defaultAppsName, state.GetCluster().Namespace, values)
+			err := state.GetFramework().MC().GetHelmValues(defaultAppsName, state.GetCluster().GetNamespace(), values)
 			Expect(err).NotTo(HaveOccurred())
 
 			resolver = &net.Resolver{

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.0
-	github.com/giantswarm/clustertest v0.2.0
+	github.com/giantswarm/clustertest v0.3.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.0 h1:ZPIiq27zJ2VatrWH21/dK6jR9rJrr4VJUP/Fo0GvsPE=
 github.com/giantswarm/apiextensions-application v0.6.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/clustertest v0.2.0 h1:OX6kSOscm6Yn4OhiX3+vcUvIBYzSlKbYL+1IE3D8Dr0=
-github.com/giantswarm/clustertest v0.2.0/go.mod h1:+XvsS0/Ix2mxmVE00i65SSYKwNBVXOkNM5JsrScikTE=
+github.com/giantswarm/clustertest v0.3.0 h1:Wj9DPboPn9hcXkEBegy3L1JCaN2hMQfwY4EceAZahdg=
+github.com/giantswarm/clustertest v0.3.0/go.mod h1:+XvsS0/Ix2mxmVE00i65SSYKwNBVXOkNM5JsrScikTE=
 github.com/giantswarm/k8smetadata v0.21.0 h1:NeLh8thaQf3iRobPhP94qF8kd7KUU65gUUNSkwFfu+E=
 github.com/giantswarm/k8smetadata v0.21.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.41.0 h1:UDxf82xWSQ9eD/EZlu859GnxgNFxfc38c8ic3i8zUag=

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/giantswarm/cluster-test-suites/common"
-	"github.com/giantswarm/cluster-test-suites/internal/state"
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/wait"
+
+	"github.com/giantswarm/cluster-test-suites/common"
+	"github.com/giantswarm/cluster-test-suites/internal/state"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,7 +24,7 @@ func Run() {
 
 		It("has all the control-plane nodes running", func() {
 			values := &application.ClusterValues{}
-			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.Namespace, values)
+			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.GetNamespace(), values)
 			Expect(err).NotTo(HaveOccurred())
 
 			wcClient, err := state.GetFramework().WC(cluster.Name)
@@ -37,7 +38,7 @@ func Run() {
 
 		It("has all the worker nodes running", func() {
 			values := &application.ClusterValues{}
-			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.Namespace, values)
+			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.GetNamespace(), values)
 			Expect(err).NotTo(HaveOccurred())
 
 			wcClient, err := state.GetFramework().WC(cluster.Name)
@@ -83,7 +84,7 @@ func Run() {
 
 		It("has all the control-plane nodes running", func() {
 			values := &application.ClusterValues{}
-			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.Namespace, values)
+			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.GetNamespace(), values)
 			Expect(err).NotTo(HaveOccurred())
 
 			wcClient, err := state.GetFramework().WC(cluster.Name)
@@ -97,7 +98,7 @@ func Run() {
 
 		It("has all the worker nodes running", func() {
 			values := &application.ClusterValues{}
-			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.Namespace, values)
+			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.GetNamespace(), values)
 			Expect(err).NotTo(HaveOccurred())
 
 			wcClient, err := state.GetFramework().WC(cluster.Name)

--- a/providers/capa/standard/capa_suite_test.go
+++ b/providers/capa/standard/capa_suite_test.go
@@ -42,7 +42,7 @@ func setUpWorkloadCluster() *application.Cluster {
 	cluster, err := state.GetFramework().LoadCluster()
 	Expect(err).NotTo(HaveOccurred())
 	if cluster != nil {
-		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.Namespace)
+		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.GetNamespace())
 		return cluster
 	}
 

--- a/providers/capa/standard/capa_test.go
+++ b/providers/capa/standard/capa_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Common tests", func() {
 
 	It("has all the control-plane nodes running", func() {
 		values := &application.ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().Namespace, values)
+		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
 		Expect(err).NotTo(HaveOccurred())
 
 		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
@@ -34,7 +34,7 @@ var _ = Describe("Common tests", func() {
 
 	It("has all the worker nodes running", func() {
 		values := &application.ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().Namespace, values)
+		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
 		Expect(err).NotTo(HaveOccurred())
 
 		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)

--- a/providers/capa/upgrade/capa_suite_test.go
+++ b/providers/capa/upgrade/capa_suite_test.go
@@ -49,7 +49,7 @@ func setUpWorkloadCluster() *application.Cluster {
 	cluster, err := state.GetFramework().LoadCluster()
 	Expect(err).NotTo(HaveOccurred())
 	if cluster != nil {
-		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.Namespace)
+		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.GetNamespace())
 		return cluster
 	}
 

--- a/providers/capv/standard/capv_suite_test.go
+++ b/providers/capv/standard/capv_suite_test.go
@@ -10,12 +10,13 @@ import (
 
 	cr "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/cluster-test-suites/internal/state"
-	"github.com/giantswarm/cluster-test-suites/providers/capv"
 	"github.com/giantswarm/clustertest"
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/wait"
+
+	"github.com/giantswarm/cluster-test-suites/internal/state"
+	"github.com/giantswarm/cluster-test-suites/providers/capv"
 )
 
 const (
@@ -46,7 +47,7 @@ func setUpWorkloadCluster() *application.Cluster {
 	cluster, err := state.GetFramework().LoadCluster()
 	Expect(err).NotTo(HaveOccurred())
 	if cluster != nil {
-		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.Namespace)
+		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.GetNamespace())
 		return cluster
 	}
 

--- a/providers/capv/upgrade/capv_suite_test.go
+++ b/providers/capv/upgrade/capv_suite_test.go
@@ -49,7 +49,7 @@ func setUpWorkloadCluster() *application.Cluster {
 	cluster, err := state.GetFramework().LoadCluster()
 	Expect(err).NotTo(HaveOccurred())
 	if cluster != nil {
-		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.Namespace)
+		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.GetNamespace())
 		return cluster
 	}
 

--- a/providers/capvcd/standard/capvcd_test.go
+++ b/providers/capvcd/standard/capvcd_test.go
@@ -20,7 +20,7 @@ var _ = PDescribe("Common tests", func() {
 
 	It("has all the control-plane nodes running", func() {
 		values := &application.ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().Namespace, values)
+		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
 		Expect(err).NotTo(HaveOccurred())
 
 		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
@@ -34,7 +34,7 @@ var _ = PDescribe("Common tests", func() {
 
 	It("has all the worker nodes running", func() {
 		values := &application.ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().Namespace, values)
+		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
 		Expect(err).NotTo(HaveOccurred())
 
 		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)

--- a/providers/capvcd/upgrade/capvcd_suite_test.go
+++ b/providers/capvcd/upgrade/capvcd_suite_test.go
@@ -49,7 +49,7 @@ func setUpWorkloadCluster() *application.Cluster {
 	cluster, err := state.GetFramework().LoadCluster()
 	Expect(err).NotTo(HaveOccurred())
 	if cluster != nil {
-		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.Namespace)
+		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.GetNamespace())
 		return cluster
 	}
 

--- a/providers/capz/standard/capz_test.go
+++ b/providers/capz/standard/capz_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Common tests", func() {
 
 	It("has all the control-plane nodes running", func() {
 		values := &ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().Namespace, values)
+		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
 		Expect(err).NotTo(HaveOccurred())
 
 		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
@@ -42,7 +42,7 @@ var _ = Describe("Common tests", func() {
 
 	It("has all the worker nodes running", func() {
 		values := &ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().Namespace, values)
+		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
 		Expect(err).NotTo(HaveOccurred())
 
 		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)

--- a/providers/capz/upgrade/capz_suite_test.go
+++ b/providers/capz/upgrade/capz_suite_test.go
@@ -49,7 +49,7 @@ func setUpWorkloadCluster() *application.Cluster {
 	cluster, err := state.GetFramework().LoadCluster()
 	Expect(err).NotTo(HaveOccurred())
 	if cluster != nil {
-		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.Namespace)
+		logger.Log("Using existing cluster %s/%s", cluster.Name, cluster.GetNamespace())
 		return cluster
 	}
 


### PR DESCRIPTION
### What this PR does
Bump clustertest to v0.3.0 to be able to set app organization.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/run cluster-test-suites
