### PR TITLE
Shrink container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.github
+.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Shrink container image by excluding build artifacts and language files.
+
 ## [1.11.0] - 2023-08-29
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN ginkgo build --skip-package /X -r ./
 
 FROM debian:bookworm-slim
 
+WORKDIR /app
+
 RUN apt-get update \
   && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN ginkgo build --skip-package /X -r ./
 
 FROM debian:bookworm-slim
 
+RUN apt-get update \
+  && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build-tests /app /app
 COPY --from=build-tests /go/bin/ginkgo /usr/local/bin/ginkgo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.20 AS build-tests
 
 WORKDIR /app
 
@@ -14,5 +14,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o standup ./cmd/standup/
 RUN CGO_ENABLED=0 GOOS=linux go build -o teardown ./cmd/teardown/
 
 RUN ginkgo build --skip-package /X -r ./
+
+FROM debian:bookworm-slim
+
+COPY --from=build-tests /app /app
+COPY --from=build-tests /go/bin/ginkgo /usr/local/bin/ginkgo
 
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
### What this PR does

This PR attempts to shrink the container image from currently ~3GB down to ~1GB by putting test binaries into a clean debian:slim container image

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
