### PR TITLE
Refactor node tests with new ClusterValues unmarshalling fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated readme info
 
+### Changed
+
+- Bumped `clustertest` to v0.3.1 with fix for `ClusterValues` unmarshalling if different `NodePool` types
+- Refactored node tests to reuse code now the `NodePool` type fix is in `clustertest`
+
 ## [1.11.0] - 2023-08-29
 
 ### Added

--- a/common/basic.go
+++ b/common/basic.go
@@ -38,6 +38,34 @@ func runBasic() {
 			Expect(wcClient.CheckConnection()).To(Succeed())
 		})
 
+		It("has all the control-plane nodes running", func() {
+			values := &application.ClusterValues{}
+			err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
+			Expect(err).NotTo(HaveOccurred())
+
+			wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(wait.Consistent(CheckControlPlaneNodesReady(wcClient, values.ControlPlane), 12, 5*time.Second)).
+				WithTimeout(wait.DefaultTimeout).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+
+		It("has all the worker nodes running", func() {
+			values := &application.ClusterValues{}
+			err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
+			Expect(err).NotTo(HaveOccurred())
+
+			wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(wait.Consistent(CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
+				WithTimeout(wait.DefaultTimeout).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+
 		It("has all of it's Pods in the Running state", func() {
 			Eventually(wait.Consistent(checkAllPodsSuccessfulPhase(wcClient), 10, time.Second)).
 				WithTimeout(wait.DefaultTimeout).

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.0
-	github.com/giantswarm/clustertest v0.3.0
+	github.com/giantswarm/clustertest v0.3.1
 	github.com/onsi/ginkgo/v2 v2.12.0
 	github.com/onsi/gomega v1.27.10
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.0 h1:ZPIiq27zJ2VatrWH21/dK6jR9rJrr4VJUP/Fo0GvsPE=
 github.com/giantswarm/apiextensions-application v0.6.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/clustertest v0.3.0 h1:Wj9DPboPn9hcXkEBegy3L1JCaN2hMQfwY4EceAZahdg=
-github.com/giantswarm/clustertest v0.3.0/go.mod h1:+XvsS0/Ix2mxmVE00i65SSYKwNBVXOkNM5JsrScikTE=
+github.com/giantswarm/clustertest v0.3.1 h1:k7NE4BIzdRAu/muaPhcuAT1vnBQhVf7Z8qkZ2M+ATZE=
+github.com/giantswarm/clustertest v0.3.1/go.mod h1:+XvsS0/Ix2mxmVE00i65SSYKwNBVXOkNM5JsrScikTE=
 github.com/giantswarm/k8smetadata v0.21.0 h1:NeLh8thaQf3iRobPhP94qF8kd7KUU65gUUNSkwFfu+E=
 github.com/giantswarm/k8smetadata v0.21.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.41.0 h1:UDxf82xWSQ9eD/EZlu859GnxgNFxfc38c8ic3i8zUag=

--- a/providers/capa/standard/capa_test.go
+++ b/providers/capa/standard/capa_test.go
@@ -1,48 +1,13 @@
 package standard
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	"github.com/giantswarm/clustertest/pkg/application"
-	"github.com/giantswarm/clustertest/pkg/wait"
 
 	"github.com/giantswarm/cluster-test-suites/common"
-	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
 
 var _ = Describe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		BastionSupported: true,
-	})
-
-	It("has all the control-plane nodes running", func() {
-		values := &application.ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
-		Expect(err).NotTo(HaveOccurred())
-
-		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
-		Expect(err).NotTo(HaveOccurred())
-
-		Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, values.ControlPlane), 12, 5*time.Second)).
-			WithTimeout(wait.DefaultTimeout).
-			WithPolling(wait.DefaultInterval).
-			Should(Succeed())
-	})
-
-	It("has all the worker nodes running", func() {
-		values := &application.ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
-		Expect(err).NotTo(HaveOccurred())
-
-		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
-		Expect(err).NotTo(HaveOccurred())
-
-		Eventually(wait.Consistent(common.CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
-			WithTimeout(wait.DefaultTimeout).
-			WithPolling(wait.DefaultInterval).
-			Should(Succeed())
 	})
 })

--- a/providers/capvcd/standard/capvcd_test.go
+++ b/providers/capvcd/standard/capvcd_test.go
@@ -1,48 +1,13 @@
 package standard
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	"github.com/giantswarm/clustertest/pkg/application"
-	"github.com/giantswarm/clustertest/pkg/wait"
 
 	"github.com/giantswarm/cluster-test-suites/common"
-	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
 
 var _ = PDescribe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		BastionSupported: true,
-	})
-
-	It("has all the control-plane nodes running", func() {
-		values := &application.ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
-		Expect(err).NotTo(HaveOccurred())
-
-		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
-		Expect(err).NotTo(HaveOccurred())
-
-		Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, values.ControlPlane), 12, 5*time.Second)).
-			WithTimeout(wait.DefaultTimeout).
-			WithPolling(wait.DefaultInterval).
-			Should(Succeed())
-	})
-
-	It("has all the worker nodes running", func() {
-		values := &application.ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
-		Expect(err).NotTo(HaveOccurred())
-
-		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
-		Expect(err).NotTo(HaveOccurred())
-
-		Eventually(wait.Consistent(common.CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
-			WithTimeout(wait.DefaultTimeout).
-			WithPolling(wait.DefaultInterval).
-			Should(Succeed())
 	})
 })

--- a/providers/capz/standard/capz_test.go
+++ b/providers/capz/standard/capz_test.go
@@ -3,17 +3,14 @@ package standard
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/giantswarm/clustertest/pkg/client"
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/wait"
 
 	"github.com/giantswarm/cluster-test-suites/common"
-	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
 
 type ClusterValues struct {
@@ -24,34 +21,6 @@ type ClusterValues struct {
 var _ = Describe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		BastionSupported: true,
-	})
-
-	It("has all the control-plane nodes running", func() {
-		values := &ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
-		Expect(err).NotTo(HaveOccurred())
-
-		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
-		Expect(err).NotTo(HaveOccurred())
-
-		Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, values.ControlPlane), 12, 5*time.Second)).
-			WithTimeout(wait.DefaultTimeout).
-			WithPolling(wait.DefaultInterval).
-			Should(Succeed())
-	})
-
-	It("has all the worker nodes running", func() {
-		values := &ClusterValues{}
-		err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
-		Expect(err).NotTo(HaveOccurred())
-
-		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
-		Expect(err).NotTo(HaveOccurred())
-
-		Eventually(wait.Consistent(CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
-			WithTimeout(wait.DefaultTimeout).
-			WithPolling(wait.DefaultInterval).
-			Should(Succeed())
 	})
 })
 


### PR DESCRIPTION
### What this PR does

- Bumped `clustertest` to v0.3.1 with fix for `ClusterValues` unmarshalling if different `NodePool` types
- Refactored node tests to reuse code now the `NodePool` type fix is in `clustertest`

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
