### PR TITLE
Use cluster-aws defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Shrink container image by excluding build artifacts and language files.
+- Rely on `cluster-aws` default values when installing the chart.
 
 ### Docs
 

--- a/providers/capa/standard/test_data/cluster_values.yaml
+++ b/providers/capa/standard/test_data/cluster_values.yaml
@@ -3,6 +3,10 @@ metadata:
   description: "E2E Test cluster"
   organization: "{{ .Organization }}"
 
+# We need to pass the node pools otherwise the test called "has all the worker nodes running" will fail because it
+# expects to find the number of worker nodes in the helm values, but the value is not there if don't pass it, as it's
+# defaulted in the chart template.
+# @TODO: https://github.com/giantswarm/giantswarm/issues/28063
 nodePools:
   pool0:
     maxSize: 2

--- a/providers/capa/standard/test_data/cluster_values.yaml
+++ b/providers/capa/standard/test_data/cluster_values.yaml
@@ -2,3 +2,8 @@ metadata:
   name: "{{ .ClusterName }}"
   description: "E2E Test cluster"
   organization: "{{ .Organization }}"
+
+nodePools:
+  pool0:
+    maxSize: 2
+    minSize: 2

--- a/providers/capa/standard/test_data/cluster_values.yaml
+++ b/providers/capa/standard/test_data/cluster_values.yaml
@@ -2,16 +2,3 @@ metadata:
   name: "{{ .ClusterName }}"
   description: "E2E Test cluster"
   organization: "{{ .Organization }}"
-
-controlPlane:
-  replicas: 3
-nodePools:
-  pool0:
-    instanceType: m5.xlarge
-    maxSize: 10
-    minSize: 3
-    rootVolumeSizeGB: 300
-connectivity:
-  availabilityZoneUsageLimit: 3
-  bastion:
-    enabled: true

--- a/providers/capa/upgrade/test_data/cluster_values.yaml
+++ b/providers/capa/upgrade/test_data/cluster_values.yaml
@@ -3,15 +3,7 @@ metadata:
   description: "E2E Test cluster"
   organization: "{{ .Organization }}"
 
-controlPlane:
-  replicas: 3
 nodePools:
   pool0:
-    instanceType: m5.xlarge
-    maxSize: 10
-    minSize: 3
-    rootVolumeSizeGB: 300
-connectivity:
-  availabilityZoneUsageLimit: 3
-  bastion:
-    enabled: true
+    maxSize: 2
+    minSize: 2

--- a/providers/capa/upgrade/test_data/cluster_values.yaml
+++ b/providers/capa/upgrade/test_data/cluster_values.yaml
@@ -3,6 +3,10 @@ metadata:
   description: "E2E Test cluster"
   organization: "{{ .Organization }}"
 
+# We need to pass the node pools otherwise the test called "has all the worker nodes running" will fail because it
+# expects to find the number of worker nodes in the helm values, but the value is not there if don't pass it, as it's
+# defaulted in the chart template.
+# @TODO: https://github.com/giantswarm/giantswarm/issues/28063
 nodePools:
   pool0:
     maxSize: 2


### PR DESCRIPTION
### What this PR does
Towards https://github.com/giantswarm/giantswarm/issues/27925

Rely more on `cluster-aws` defaults. This would allow us to always use the right instance type, which we should have reserved on AWS to save money.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
