### PR TITLE
Refactored app status checks to use helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored the various app status checks to make use of the helper functions in `clustertest`
+- Updated `clustertest` to v0.4.0
+
 ## [1.12.0] - 2023-09-12
 
 ### Added

--- a/common/apps.go
+++ b/common/apps.go
@@ -5,16 +5,14 @@ import (
 	"time"
 
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
-	"github.com/giantswarm/clustertest/pkg/logger"
+	"github.com/giantswarm/clustertest/pkg/wait"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
-
-const deployedStatus = "deployed"
 
 func runApps() {
 	Context("default apps", func() {
@@ -22,46 +20,26 @@ func runApps() {
 
 			// We need to wait for default-apps to be deployed before we can check all apps.
 			defaultAppsAppName := fmt.Sprintf("%s-%s", state.GetCluster().Name, "default-apps")
-			Eventually(func() error {
-				app, err := state.GetFramework().GetApp(state.GetContext(), defaultAppsAppName, state.GetCluster().Organization.GetNamespace())
-				if err != nil {
-					return err
-				}
-				return checkAppStatus(app)
-			}).
+
+			Eventually(wait.IsAppStatus(state.GetContext(), state.GetFramework().MC(), defaultAppsAppName, state.GetCluster().Organization.GetNamespace(), "deployed")).
 				WithTimeout(30 * time.Second).
 				WithPolling(50 * time.Millisecond).
-				Should(Succeed())
+				Should(BeTrue())
 
 			// Wait for all default-apps apps to be deployed
-			Eventually(func() error {
-				appList := &v1alpha1.AppList{}
-				err := state.GetFramework().MC().List(state.GetContext(), appList, ctrl.InNamespace(state.GetCluster().Organization.GetNamespace()), ctrl.MatchingLabels{"giantswarm.io/managed-by": defaultAppsAppName})
-				if err != nil {
-					return err
-				}
+			appList := &v1alpha1.AppList{}
+			err := state.GetFramework().MC().List(state.GetContext(), appList, ctrl.InNamespace(state.GetCluster().Organization.GetNamespace()), ctrl.MatchingLabels{"giantswarm.io/managed-by": defaultAppsAppName})
+			Expect(err).NotTo(HaveOccurred())
 
-				logger.Log("Checking status of %d apps", len(appList.Items))
-				errs := []error{}
-				for _, app := range appList.Items {
-					if err := checkAppStatus(&app); err != nil {
-						errs = append(errs, err)
-					}
-				}
-				return errors.NewAggregate(errs)
-			}).
+			appNamespacedNames := []types.NamespacedName{}
+			for _, app := range appList.Items {
+				appNamespacedNames = append(appNamespacedNames, types.NamespacedName{Name: app.Name, Namespace: app.Namespace})
+			}
+
+			Eventually(wait.IsAllAppDeployed(state.GetContext(), state.GetFramework().MC(), appNamespacedNames)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(10 * time.Second).
-				Should(Succeed())
-
+				Should(BeTrue())
 		})
 	})
-}
-
-func checkAppStatus(app *v1alpha1.App) error {
-	if app.Status.Release.Status != deployedStatus {
-		logger.Log("App %s status is currently '%s'", app.Name, app.Status.Release.Status)
-		return fmt.Errorf("app %s status is '%s'", app.Name, app.Status.Release.Status)
-	}
-	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.0
-	github.com/giantswarm/clustertest v0.3.1
+	github.com/giantswarm/clustertest v0.4.0
 	github.com/onsi/ginkgo/v2 v2.12.0
 	github.com/onsi/gomega v1.27.10
 	github.com/spf13/cobra v1.7.0
@@ -69,7 +69,7 @@ require (
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/go-github/v54 v54.0.0 // indirect
+	github.com/google/go-github/v55 v55.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20230406165453-00490a63f317 // indirect

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.0 h1:ZPIiq27zJ2VatrWH21/dK6jR9rJrr4VJUP/Fo0GvsPE=
 github.com/giantswarm/apiextensions-application v0.6.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/clustertest v0.3.1 h1:k7NE4BIzdRAu/muaPhcuAT1vnBQhVf7Z8qkZ2M+ATZE=
-github.com/giantswarm/clustertest v0.3.1/go.mod h1:+XvsS0/Ix2mxmVE00i65SSYKwNBVXOkNM5JsrScikTE=
+github.com/giantswarm/clustertest v0.4.0 h1:zFGqq5m/eTjx62CNQpMp4rpyJfG5VKMELtP9AlRQp6s=
+github.com/giantswarm/clustertest v0.4.0/go.mod h1:YfS5YnCNzuaNg9K2ef/IfzFtcZKT1k8GkizVNi06zmg=
 github.com/giantswarm/k8smetadata v0.21.0 h1:NeLh8thaQf3iRobPhP94qF8kd7KUU65gUUNSkwFfu+E=
 github.com/giantswarm/k8smetadata v0.21.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.41.0 h1:UDxf82xWSQ9eD/EZlu859GnxgNFxfc38c8ic3i8zUag=
@@ -305,8 +305,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v54 v54.0.0 h1:OZdXwow4EAD5jEo5qg+dGFH2DpkyZvVsAehjvJuUL/c=
-github.com/google/go-github/v54 v54.0.0/go.mod h1:Sw1LXWHhXRZtzJ9LI5fyJg9wbQzYvFhW8W5P2yaAQ7s=
+github.com/google/go-github/v55 v55.0.0 h1:4pp/1tNMB9X/LuAhs5i0KQAE40NmiR/y6prLNb9x9cg=
+github.com/google/go-github/v55 v55.0.0/go.mod h1:JLahOTA1DnXzhxEymmFF5PP2tSS9JVNj68mSZNDwskA=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -67,7 +67,7 @@ func Run() {
 			).Should(BeTrue())
 
 			Eventually(
-				wait.IsAppStatus(state.GetContext(), state.GetFramework().MC(), defaultAppsApp.Name, defaultAppsApp.Namespace, "deployed"),
+				wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), defaultAppsApp.Name, defaultAppsApp.Namespace),
 				10*time.Minute, 5*time.Second,
 			).Should(BeTrue())
 
@@ -77,7 +77,7 @@ func Run() {
 			).Should(BeTrue())
 
 			Eventually(
-				wait.IsAppStatus(state.GetContext(), state.GetFramework().MC(), clusterApp.Name, clusterApp.Namespace, "deployed"),
+				wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), clusterApp.Name, clusterApp.Namespace),
 				10*time.Minute, 5*time.Second,
 			).Should(BeTrue())
 		})


### PR DESCRIPTION
### What this PR does

Replaced the custom App status checks with the helper functions from the latest `clustertest` release (v0.4.0)

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
