### PR TITLE
Bump clustertest to 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `clustertest` to v0.12.1` to fix upgrade tests.
+
 ## [1.16.0] - 2023-11-02
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.1
-	github.com/giantswarm/clustertest v0.12.0
+	github.com/giantswarm/clustertest v0.12.1
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.29.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkPJa+rXKBr9e0p+6nd8aw3A=
 github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/clustertest v0.12.0 h1:t7b9Ka6rLxBj5UGA0kcsWZRSMesv8Eb46rSmiLsZFdg=
-github.com/giantswarm/clustertest v0.12.0/go.mod h1:pkEL5WPpAgxpZ4QGH5cAPV4VSRd4LkjqZ5rwTlu+OwY=
+github.com/giantswarm/clustertest v0.12.1 h1:J1AjFO/AF87MJeKzgIQVmojLaiuuwWhGTYdlCL+Mum4=
+github.com/giantswarm/clustertest v0.12.1/go.mod h1:pkEL5WPpAgxpZ4QGH5cAPV4VSRd4LkjqZ5rwTlu+OwY=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=
 github.com/giantswarm/k8smetadata v0.23.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.45.0 h1:4g1Fnpkf4gjxiZtFPCEIfEnEWVIpoTXj1yij4hxaOok=


### PR DESCRIPTION
### What this PR does

We need to consume this patch to have the fix here https://github.com/giantswarm/clustertest/pull/117

It is necessary for upgrade tests. 

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
