### PR TITLE
Increase timeout for default-apps wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase timeout for default-apps-$provider app.
+
 ## [1.17.0] - 2023-11-15
 
 ### Added

--- a/internal/common/apps.go
+++ b/internal/common/apps.go
@@ -22,8 +22,8 @@ func runApps() {
 			defaultAppsAppName := fmt.Sprintf("%s-%s", state.GetCluster().Name, "default-apps")
 
 			Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), defaultAppsAppName, state.GetCluster().Organization.GetNamespace())).
-				WithTimeout(30 * time.Second).
-				WithPolling(50 * time.Millisecond).
+				WithTimeout(5 * time.Minute).
+				WithPolling(1 * time.Second).
 				Should(BeTrue())
 
 			// Wait for all default-apps apps to be deployed


### PR DESCRIPTION
app-operator sometimes behaves slowly and doesn't reconcile the default-apps immediately. It can take a few minutes in some cases.

Failure example (Re-run worked): https://tekton.ei9o7.k8s.gorilla.eu-central-1.aws.gigantic.io/#/namespaces/tekton-pipelines/pipelineruns/pr-default-apps-vsphere-170-cluster-test-suites98fgh?pipelineTask=run-tests&step=run-tests&taskRunName=pr-default-apps-vsp2b7622e4aa140545bb755731d9bb9df7-run-tests-0

### What this PR does


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
