### PR TITLE
Re-enabled CAPVCD tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Re-enabled CAPVCD tests
+
 ## [1.17.0] - 2023-11-15
 
 ### Added

--- a/providers/capvcd/standard/capvcd_test.go
+++ b/providers/capvcd/standard/capvcd_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = PDescribe("Common tests", func() {
+var _ = Describe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		BastionSupported: true,
 		// Disabled until https://github.com/giantswarm/roadmap/issues/1037


### PR DESCRIPTION
### What this PR does

Re-enabled running the CAPVCD tests now that the new MC has been set up.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
