### PR TITLE
add cross-provider observability-bundle test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `observability-bundle` test in the common/apps.go file.
+
 ## [1.17.1] - 2023-11-26
 
 ### Changed


### PR DESCRIPTION
### What this PR does

Towards https://github.com/giantswarm/giantswarm/issues/28547
This PR adds a cross-provider test to check if all observability-bundle apps are deployed correctly.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
