### PR TITLE
Include both schemas in values during migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- include both schema versions in CAPA cluster values file while migration is underway
+
 ## [1.19.0] - 2023-12-01
 
 ### Added

--- a/providers/capa/standard/test_data/cluster_values.yaml
+++ b/providers/capa/standard/test_data/cluster_values.yaml
@@ -22,3 +22,22 @@ global:
       spotInstances:
         enabled: true
         maxPrice: 0.2960
+
+# TODO: Old Schema - to be deleted when migration complete
+metadata:
+  name: "{{ .ClusterName }}"
+  description: "E2E Test cluster"
+  organization: "{{ .Organization }}"
+controlPlane:
+  containerdVolumeSizeGB: 15
+  etcdVolumeSizeGB: 50
+  kubeletVolumeSizeGB: 10
+  rootVolumeSizeGB: 10
+nodePools:
+  pool0:
+    maxSize: 2
+    minSize: 1
+    rootVolumeSizeGB: 25
+    spotInstances:
+      enabled: true
+      maxPrice: 0.2960

--- a/providers/capa/upgrade/test_data/cluster_values.yaml
+++ b/providers/capa/upgrade/test_data/cluster_values.yaml
@@ -1,18 +1,38 @@
+global:
+  metadata:
+    name: "{{ .ClusterName }}"
+    description: "E2E Test cluster"
+    organization: "{{ .Organization }}"
+
+  controlPlane:
+    containerdVolumeSizeGB: 15
+    etcdVolumeSizeGB: 50
+    kubeletVolumeSizeGB: 10
+    rootVolumeSizeGB: 10
+
+  # We need to pass the node pools otherwise the test called "has all the worker nodes running" will fail because it
+  # expects to find the number of worker nodes in the helm values, but the value is not there if don't pass it, as it's
+  # defaulted in the chart template.
+  # @TODO: https://github.com/giantswarm/giantswarm/issues/28063
+  nodePools:
+    pool0:
+      maxSize: 2
+      minSize: 1
+      rootVolumeSizeGB: 25
+      spotInstances:
+        enabled: true
+        maxPrice: 0.2960
+
+# TODO: Old Schema - to be deleted when migration complete
 metadata:
   name: "{{ .ClusterName }}"
   description: "E2E Test cluster"
   organization: "{{ .Organization }}"
-
 controlPlane:
   containerdVolumeSizeGB: 15
   etcdVolumeSizeGB: 50
   kubeletVolumeSizeGB: 10
   rootVolumeSizeGB: 10
-
-# We need to pass the node pools otherwise the test called "has all the worker nodes running" will fail because it
-# expects to find the number of worker nodes in the helm values, but the value is not there if don't pass it, as it's
-# defaulted in the chart template.
-# @TODO: https://github.com/giantswarm/giantswarm/issues/28063
 nodePools:
   pool0:
     maxSize: 2


### PR DESCRIPTION
### What this PR does

Includes both the old and new schema of cluster values to ensure the tests can still be run while the migration is underway.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
