### PR TITLE
Remove old schema from cluster-aws values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed the old schema from the cluster-aws values
+
 ## [1.19.1] - 2023-12-04
 
 ### Fixed

--- a/providers/capa/standard/test_data/cluster_values.yaml
+++ b/providers/capa/standard/test_data/cluster_values.yaml
@@ -22,22 +22,3 @@ global:
       spotInstances:
         enabled: true
         maxPrice: 0.2960
-
-# TODO: Old Schema - to be deleted when migration complete
-metadata:
-  name: "{{ .ClusterName }}"
-  description: "E2E Test cluster"
-  organization: "{{ .Organization }}"
-controlPlane:
-  containerdVolumeSizeGB: 15
-  etcdVolumeSizeGB: 50
-  kubeletVolumeSizeGB: 10
-  rootVolumeSizeGB: 10
-nodePools:
-  pool0:
-    maxSize: 2
-    minSize: 1
-    rootVolumeSizeGB: 25
-    spotInstances:
-      enabled: true
-      maxPrice: 0.2960

--- a/providers/capa/upgrade/test_data/cluster_values.yaml
+++ b/providers/capa/upgrade/test_data/cluster_values.yaml
@@ -22,22 +22,3 @@ global:
       spotInstances:
         enabled: true
         maxPrice: 0.2960
-
-# TODO: Old Schema - to be deleted when migration complete
-metadata:
-  name: "{{ .ClusterName }}"
-  description: "E2E Test cluster"
-  organization: "{{ .Organization }}"
-controlPlane:
-  containerdVolumeSizeGB: 15
-  etcdVolumeSizeGB: 50
-  kubeletVolumeSizeGB: 10
-  rootVolumeSizeGB: 10
-nodePools:
-  pool0:
-    maxSize: 2
-    minSize: 1
-    rootVolumeSizeGB: 25
-    spotInstances:
-      enabled: true
-      maxPrice: 0.2960


### PR DESCRIPTION
### What this PR does

Removes the old schema format from the cluster-aws values files.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
