### PR TITLE
Fix observability-bundle failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Increased timeout for observability-bundle apps.
+
 ## [1.19.2] - 2023-12-04
 
 ### Fixed

--- a/internal/common/apps.go
+++ b/internal/common/apps.go
@@ -64,7 +64,7 @@ func runApps() {
 			}
 
 			Eventually(wait.IsAllAppDeployed(state.GetContext(), state.GetFramework().MC(), appNamespacedNames)).
-				WithTimeout(15 * time.Minute).
+				WithTimeout(25 * time.Minute).
 				WithPolling(10 * time.Second).
 				Should(BeTrue())
 		})


### PR DESCRIPTION
### What this PR does

This PR increases the timeout period for observability-bundle apps from 15 to 25min. As some tests run by the CI are failing whereas all those run manually succeeded, I guess this is mainly caused by the short timeout period which doesn't give enough time for the apps to deploy. 

If this doesn't work, I'll try to add more log outputs for the tests to have a description of the apps' events.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
