### PR TITLE
Add test config for upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add test config for upgrades to be able to customize timeouts per provider.
+
 ## [1.20.2] - 2023-12-13
 
 - Disable Bastion tests for `capa` provider.

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -14,7 +14,19 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func Run() {
+type TestConfig struct {
+	ControlPlaneNodesTimeout time.Duration
+	WorkerNodesTimeout       time.Duration
+}
+
+func NewTestConfigWithDefaults() *TestConfig {
+	return &TestConfig{
+		ControlPlaneNodesTimeout: 15 * time.Minute,
+		WorkerNodesTimeout:       15 * time.Minute,
+	}
+}
+
+func Run(cfg *TestConfig) {
 	Context("upgrade", func() {
 		var cluster *application.Cluster
 
@@ -30,7 +42,7 @@ func Run() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, int(replicas)), 12, 5*time.Second)).
-				WithTimeout(15 * time.Minute).
+				WithTimeout(cfg.ControlPlaneNodesTimeout).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
@@ -44,7 +56,7 @@ func Run() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(wait.Consistent(common.CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
-				WithTimeout(15 * time.Minute).
+				WithTimeout(cfg.WorkerNodesTimeout).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
@@ -89,7 +101,7 @@ func Run() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, int(replicas)), 12, 5*time.Second)).
-				WithTimeout(15 * time.Minute).
+				WithTimeout(cfg.ControlPlaneNodesTimeout).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
@@ -103,7 +115,7 @@ func Run() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(wait.Consistent(common.CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
-				WithTimeout(15 * time.Minute).
+				WithTimeout(cfg.WorkerNodesTimeout).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})

--- a/providers/capa/upgrade/capa_test.go
+++ b/providers/capa/upgrade/capa_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = Describe("Basic upgrade test", Ordered, func() {
-	upgrade.Run()
+	upgrade.Run(upgrade.NewTestConfigWithDefaults())
 
 	// Finally run the common tests after upgrade is completed
 	common.Run(&common.TestConfig{

--- a/providers/capv/upgrade/capv_test.go
+++ b/providers/capv/upgrade/capv_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = Describe("Basic upgrade test", Ordered, func() {
-	upgrade.Run()
+	upgrade.Run(upgrade.NewTestConfigWithDefaults())
 
 	// Finally run the common tests after upgrade is completed
 	common.Run(&common.TestConfig{

--- a/providers/capvcd/upgrade/capvcd_test.go
+++ b/providers/capvcd/upgrade/capvcd_test.go
@@ -1,6 +1,8 @@
 package upgrade
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 
 	"github.com/giantswarm/cluster-test-suites/internal/common"
@@ -8,7 +10,13 @@ import (
 )
 
 var _ = Describe("Basic upgrade test", Ordered, func() {
-	upgrade.Run()
+	// it is better to get defaults at first and then customize
+	// further changes in defaults will be effective here.
+	cfg := upgrade.NewTestConfigWithDefaults()
+	cfg.ControlPlaneNodesTimeout = 30 * time.Minute
+	cfg.WorkerNodesTimeout = 30 * time.Minute
+
+	upgrade.Run(cfg)
 
 	// Finally run the common tests after upgrade is completed
 	common.Run(&common.TestConfig{

--- a/providers/capz/upgrade/capz_test.go
+++ b/providers/capz/upgrade/capz_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = Describe("Basic upgrade test", Ordered, func() {
-	upgrade.Run()
+	upgrade.Run(upgrade.NewTestConfigWithDefaults())
 
 	// Finally run the common tests after upgrade is completed
 	common.Run(&common.TestConfig{

--- a/providers/eks/upgrade/eks_test.go
+++ b/providers/eks/upgrade/eks_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = Describe("Basic upgrade test", Ordered, func() {
-	upgrade.Run()
+	upgrade.Run(upgrade.NewTestConfigWithDefaults())
 
 	// Finally run the common tests after upgrade is completed
 	common.Run(&common.TestConfig{


### PR DESCRIPTION
### What this PR does

This PR adds `TestConfig` for upgrade tests so that providers can customize timeouts. CAPVCD is much slower than others and it requires longer timeouts. 

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
