### PR TITLE
Reduce the number of CP nodes from 3 to 1 in CAPVCD tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce the number of CP nodes from 3 to 1 in CAPVCD tests in order to avoid timeouts.
+
 ## [1.20.3] - 2023-12-19
 
 ### Added

--- a/providers/capvcd/standard/test_data/cluster_values.yaml
+++ b/providers/capvcd/standard/test_data/cluster_values.yaml
@@ -1,6 +1,8 @@
 baseDomain: test.gigantic.io
 controlPlane:
   catalog: giantswarm
+  # HA is disabled temporarily due to
+  # https://github.com/giantswarm/giantswarm/issues/29353
   replicas: 1
   sizingPolicy: m1.large
   template: ubuntu-2004-kube-v1.24.10

--- a/providers/capvcd/standard/test_data/cluster_values.yaml
+++ b/providers/capvcd/standard/test_data/cluster_values.yaml
@@ -1,7 +1,7 @@
 baseDomain: test.gigantic.io
 controlPlane:
   catalog: giantswarm
-  replicas: 3
+  replicas: 1
   sizingPolicy: m1.large
   template: ubuntu-2004-kube-v1.24.10
   oidc:

--- a/providers/capvcd/upgrade/test_data/cluster_values.yaml
+++ b/providers/capvcd/upgrade/test_data/cluster_values.yaml
@@ -1,6 +1,8 @@
 baseDomain: test.gigantic.io
 controlPlane:
   catalog: giantswarm
+  # HA is disabled temporarily due to
+  # https://github.com/giantswarm/giantswarm/issues/29353
   replicas: 1
   sizingPolicy: m1.large
   template: ubuntu-2004-kube-v1.24.10

--- a/providers/capvcd/upgrade/test_data/cluster_values.yaml
+++ b/providers/capvcd/upgrade/test_data/cluster_values.yaml
@@ -1,7 +1,7 @@
 baseDomain: test.gigantic.io
 controlPlane:
   catalog: giantswarm
-  replicas: 3
+  replicas: 1
   sizingPolicy: m1.large
   template: ubuntu-2004-kube-v1.24.10
   oidc:


### PR DESCRIPTION
### What this PR does

We hit timeouts while waiting for nodes since CAPVCD is super slow in node provisioning. We think it is OK to have 1 CP in WC tests.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
