### PR TITLE
Allow basic test to retry on flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CAPA private cluster tests
 
+### Changed
+
+- Allow basic tests to be flakey and retry in case of network issues
+
 ## [1.20.4] - 2024-01-08
 
 ### Changed
@@ -26,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.20.2] - 2023-12-13
 
 - Disable Bastion tests for `capa` provider.
-  
+
 ## [1.20.1] - 2023-12-13
 
 ### Changed
@@ -38,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `clustertest` to v0.14.0 that increased the char count of cluster names to 20 chars
-- CAPV: WCs have the default deny-all network policies 
+- CAPV: WCs have the default deny-all network policies
 
 ## [1.19.3] - 2023-12-05
 

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -30,11 +30,11 @@ func runBasic() {
 			}
 		})
 
-		It("should be able to connect to MC cluster", func() {
+		It("should be able to connect to MC cluster", FlakeAttempts(3), func() {
 			Expect(state.GetFramework().MC().CheckConnection()).To(Succeed())
 		})
 
-		It("should be able to connect to WC cluster", func() {
+		It("should be able to connect to WC cluster", FlakeAttempts(3), func() {
 			Expect(wcClient.CheckConnection()).To(Succeed())
 		})
 


### PR DESCRIPTION
### What this PR does

Allows tests to retry if they fail due to, for example, flakey network.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
