### PR TITLE
Fix typo in CAPA private suite name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed typo in CAPA private suite name
+
 ## [1.21.0] - 2024-01-11
 
 ### Added

--- a/providers/capa/private/capa_suite_test.go
+++ b/providers/capa/private/capa_suite_test.go
@@ -24,7 +24,7 @@ const KubeContext = "capa-private-proxy"
 
 func TestCAPAStandard(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "CAPA Standard Suite")
+	RunSpecs(t, "CAPA Private Suite")
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
### What this PR does

Fixed a copy&paste typo.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
