### PR TITLE
Fix ClusterIssuer Eventually logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix ClusterIssuer test to actually keep checking for issues being ready until timeout
+
 ## [1.21.0] - 2024-01-11
 
 ### Added


### PR DESCRIPTION
### What this PR does

Fix the function used in the `Eventually` call to actually return a function rather than an error.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
