### PR TITLE
Use custom dialer for hello-world call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use custom dialer when calling hello-world application to avoid DNS caching the not found result
+
 ## [1.21.1] - 2024-01-11
 
 ### Fixed

--- a/internal/common/hello.go
+++ b/internal/common/hello.go
@@ -156,11 +156,13 @@ func runHelloWorld(externalDnsSupported bool) {
 				defer resp.Body.Close()
 
 				if resp.StatusCode != http.StatusOK {
+					logger.Log("Was expecting status code '%d' but actually got '%d'", http.StatusOK, resp.StatusCode)
 					return "", err
 				}
 
 				bodyBytes, err := io.ReadAll(resp.Body)
 				if err != nil {
+					logger.Log("Was not expecting the response body to be empty")
 					return "", err
 				}
 


### PR DESCRIPTION
### What this PR does

Implements a custom dialer for the HTTP client to perform the DNS lookup in code rather than relying on the host system. This should (hopefully) mean that the initial Not Found results aren't cached as the DNS nameserver is actually checked each time for the result. This should hopefully cut down on the flakey-ness of the hello-world test that fails because the domain doesn't resolve quick enough.

Fixes: https://github.com/giantswarm/giantswarm/issues/29469

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
