### PR TITLE
Disable CAPA private test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable capa private test suite until MC stability issues are solved
+
 ## [1.21.3] - 2024-01-17
 
 ### Changed

--- a/providers/capa/private/capa_test.go
+++ b/providers/capa/private/capa_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = Describe("Common tests", func() {
+var _ = XDescribe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		AutoScalingSupported: false,
 		BastionSupported:     false,


### PR DESCRIPTION
### What this PR does

Disables the CAPA private test suite until the issues with the MC stability are resolved.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
