### PR TITLE
Added retrying healthcheck to MC at start of suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a retrying healthcheck call to the MC at the start of the test suite to ensure connection is usable
+
+### Changed
+
+- Re-enabled CAPA private test suite
+
 ## [1.22.0] - 2024-01-18
 
 ### Changed

--- a/internal/suite/setup.go
+++ b/internal/suite/setup.go
@@ -43,6 +43,17 @@ func Setup(isUpgrade bool, kubeContext string, clusterBuilder ClusterBuilder, cl
 		Expect(err).NotTo(HaveOccurred())
 		state.SetFramework(framework)
 
+		// In certain cases, when connecting over the VPN, it is possible that the tunnel
+		// isn't ready and can take a short while to become usable. This attempts to wait
+		// for the connection to be usable before starting the tests.
+		Eventually(func() error {
+			logger.Log("Checking connection to MC is available")
+			return framework.MC().CheckConnection()
+		}).
+			WithTimeout(5 * time.Minute).
+			WithPolling(5 * time.Second).
+			Should(Succeed())
+
 		cluster := setUpWorkloadCluster(clusterBuilder, clusterReadyFns...)
 		state.SetCluster(cluster)
 	})

--- a/providers/capa/private/capa_test.go
+++ b/providers/capa/private/capa_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = XDescribe("Common tests", func() {
+var _ = Describe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		AutoScalingSupported: false,
 		BastionSupported:     false,


### PR DESCRIPTION
### What this PR does
Towards: https://github.com/giantswarm/giantswarm/issues/29482

Introduces a retrying check for the MC api-server being available. This is to work around a limitation of our VPN setup where it can take a short while before the VPN tunnel is useable after it has been idle for a long period of time.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
