### PR TITLE
Disable the CAPVCD tests while we recove broken MC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disabled CAPVCD tests while we recover the broken MC
+
 ## [1.23.0] - 2024-01-19
 
 ### Added

--- a/providers/capvcd/standard/capvcd_test.go
+++ b/providers/capvcd/standard/capvcd_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = Describe("Common tests", func() {
+var _ = XDescribe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		// No autoscaling on-prem
 		AutoScalingSupported: false,

--- a/providers/capvcd/upgrade/capvcd_test.go
+++ b/providers/capvcd/upgrade/capvcd_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
 )
 
-var _ = Describe("Basic upgrade test", Ordered, func() {
+var _ = XDescribe("Basic upgrade test", Ordered, func() {
 	// it is better to get defaults at first and then customize
 	// further changes in defaults will be effective here.
 	cfg := upgrade.NewTestConfigWithDefaults()


### PR DESCRIPTION
### What this PR does

Disable the CAPVCD tests while we recove broken MC

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

(Skipping tests as this is just disabling)