### PR TITLE
Increase min nodes for CAPA and make scale test dynamic to no of nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set min worker nodes to 2 for CAPA clusters
+- Make the scale test dynamic based on the current number of worker nodes
+
 ## [1.23.2] - 2024-01-26
 
 ### Changed

--- a/internal/common/scale.go
+++ b/internal/common/scale.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cr "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -42,8 +43,13 @@ func runScale(autoScalingSupported bool) {
 			ctx := context.Background()
 			org := state.GetCluster().Organization
 
+			// Get the current number of worker nodes and set the replicas to one more to force scale up
+			nodes := corev1.NodeList{}
+			err = wcClient.List(ctx, &nodes, client.DoesNotHaveLabels{"node-role.kubernetes.io/control-plane"})
+			Expect(err).To(BeNil())
+
 			helloAppValues = map[string]string{
-				"ReplicaCount": "2",
+				"ReplicaCount": fmt.Sprintf("%d", len(nodes.Items)+1),
 			}
 
 			helloApp = application.New(fmt.Sprintf("%s-scale-hello-world", state.GetCluster().Name), "hello-world").

--- a/providers/capa/private/test_data/cluster_values.yaml
+++ b/providers/capa/private/test_data/cluster_values.yaml
@@ -50,8 +50,8 @@ global:
   nodePools:
     # We are using a name with 10 chars which is the max number of characters allowed by our kyverno policies.
     nodepool-0:
-      maxSize: 2
-      minSize: 1
+      maxSize: 3
+      minSize: 2
       rootVolumeSizeGB: 25
       spotInstances:
         enabled: true

--- a/providers/capa/standard/test_data/cluster_values.yaml
+++ b/providers/capa/standard/test_data/cluster_values.yaml
@@ -17,8 +17,8 @@ global:
   nodePools:
     # We are using a name with 10 chars which is the max number of characters allowed by our kyverno policies.
     nodepool-0:
-      maxSize: 2
-      minSize: 1
+      maxSize: 3
+      minSize: 2
       rootVolumeSizeGB: 25
       spotInstances:
         enabled: true

--- a/providers/capa/upgrade/test_data/cluster_values.yaml
+++ b/providers/capa/upgrade/test_data/cluster_values.yaml
@@ -17,8 +17,8 @@ global:
   nodePools:
     # We are using a name with 10 chars which is the max number of characters allowed by our kyverno policies.
     nodepool-0:
-      maxSize: 2
-      minSize: 1
+      maxSize: 3
+      minSize: 2
       rootVolumeSizeGB: 25
       spotInstances:
         enabled: true


### PR DESCRIPTION
### What this PR does

Increases the minimum number of worker nodes on CAPA to 2 to hopefully avoid issues with the `hello-world` test not having enough resources to deploy the pod and timing out waiting for the scale up.

As part of this I have also update the scale test to be dynamic based on the current number of worker nodes found in the cluster, rather than hard coded.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
