### PR TITLE
Refactor hello-world test to split into individual, ordered cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored `hello-world` tests to split out into individual (ordered) test cases to better understand where things fail
+- Increased the timout of the `hello-world` ingress check from 10min to 15min
+- Introduced a check for the ingress resources status being updated with the load balancer hostname
+
 ## [1.24.0] - 2024-01-26
 
 ### Changed

--- a/internal/common/hello.go
+++ b/internal/common/hello.go
@@ -35,9 +35,11 @@ func runHelloWorld(externalDnsSupported bool) {
 			appReadyInterval = 5 * time.Second
 		)
 
-		if !externalDnsSupported {
-			Skip("external-dns is not supported")
-		}
+		BeforeEach(func() {
+			if !externalDnsSupported {
+				Skip("external-dns is not supported")
+			}
+		})
 
 		It("should have cert-manager and external-dns deployed", func() {
 			org := state.GetCluster().Organization

--- a/providers/capa/standard/test_data/default-apps_values.yaml
+++ b/providers/capa/standard/test_data/default-apps_values.yaml
@@ -1,2 +1,9 @@
 clusterName: "{{ .ClusterName }}"
 organization: "{{ .Organization }}"
+
+userConfig:
+  # We want to have external-dns watch for new ingress resources to speed up the DNS creation
+  externalDns:
+    configMap:
+      values:
+        triggerLoopOnEvent: true

--- a/providers/capa/upgrade/test_data/default-apps_values.yaml
+++ b/providers/capa/upgrade/test_data/default-apps_values.yaml
@@ -1,2 +1,9 @@
 clusterName: "{{ .ClusterName }}"
 organization: "{{ .Organization }}"
+
+userConfig:
+  # We want to have external-dns watch for new ingress resources to speed up the DNS creation
+  externalDns:
+    configMap:
+      values:
+        triggerLoopOnEvent: true

--- a/providers/eks/standard/test_data/default-apps_values.yaml
+++ b/providers/eks/standard/test_data/default-apps_values.yaml
@@ -1,2 +1,9 @@
 clusterName: "{{ .ClusterName }}"
 organization: "{{ .Organization }}"
+
+userConfig:
+  # We want to have external-dns watch for new ingress resources to speed up the DNS creation
+  externalDns:
+    configMap:
+      values:
+        triggerLoopOnEvent: true

--- a/providers/eks/upgrade/test_data/default-apps_values.yaml
+++ b/providers/eks/upgrade/test_data/default-apps_values.yaml
@@ -1,2 +1,9 @@
 clusterName: "{{ .ClusterName }}"
 organization: "{{ .Organization }}"
+
+userConfig:
+  # We want to have external-dns watch for new ingress resources to speed up the DNS creation
+  externalDns:
+    configMap:
+      values:
+        triggerLoopOnEvent: true


### PR DESCRIPTION
### What this PR does

* Refactors the `hello-world` tests to change them to individual, ordered test cases to get a better understanding of where things go wrong.
* Introduced a test case to check that the ingress status is updated with the load balancer hostname.
* Increased the timeout from 10 min to 15 min for the ingress test.
* Set `triggerLoopOnEvent` to true for external-dns to speed up reconciliation of Ingress resources

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
