### PR TITLE
Re-enable CAPVCD tests on gerbil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Re-enable CAPVCD tests on gerbil.
+
 ## [1.24.0] - 2024-01-26
 
 ### Changed

--- a/providers/capvcd/standard/capvcd_test.go
+++ b/providers/capvcd/standard/capvcd_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = XDescribe("Common tests", func() {
+var _ = Describe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		// No autoscaling on-prem
 		AutoScalingSupported: false,

--- a/providers/capvcd/upgrade/capvcd_test.go
+++ b/providers/capvcd/upgrade/capvcd_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
 )
 
-var _ = XDescribe("Basic upgrade test", Ordered, func() {
+var _ = Describe("Basic upgrade test", Ordered, func() {
 	// it is better to get defaults at first and then customize
 	// further changes in defaults will be effective here.
 	cfg := upgrade.NewTestConfigWithDefaults()


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/29581

### What this PR does

re-enables CAPVCD tests.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
