### PR TITLE
Add securityContext to pvc pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add security context to PVC pod.
+
 ## [1.25.0] - 2024-01-30
 
 ### Changed

--- a/assets/storage/storage.go
+++ b/assets/storage/storage.go
@@ -28,6 +28,16 @@ metadata:
   name: pvc-test-pod
   namespace: test-storage
 spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
   containers:
     - name: pvc-test-container
       image: nginx


### PR DESCRIPTION
### What this PR does

Required on CAPA as we now install the security-bundle by default

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
