### PR TITLE
Disable Bastion Support for CAPZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable Bastion Support for CAPZ
+
 ## [1.25.2] - 2024-01-31
 
 ### Changed

--- a/providers/capz/standard/capz_test.go
+++ b/providers/capz/standard/capz_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		// Disabled until https://github.com/giantswarm/roadmap/issues/2693
 		AutoScalingSupported: false,
-		BastionSupported:     true,
+		BastionSupported:     false,
 		// Disabled until wildcard ingress support is added
 		ExternalDnsSupported: false,
 	})

--- a/providers/capz/upgrade/capz_test.go
+++ b/providers/capz/upgrade/capz_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 	common.Run(&common.TestConfig{
 		// Disabled until https://github.com/giantswarm/roadmap/issues/2693
 		AutoScalingSupported: false,
-		BastionSupported:     true,
+		BastionSupported:     false,
 		// Disabled until wildcard ingress support is added
 		ExternalDnsSupported: false,
 	})


### PR DESCRIPTION
Towards https://github.com/giantswarm/wepa/issues/51

### What this PR does

- Disables bastion support for CAPZ

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
