### PR TITLE
Fix upgrade tests not installing latest released first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure upgrade tests install latest released version first
+
 ## [1.26.1] - 2024-02-12
 
 ### Changed


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/giantswarm/giantswarm/issues/29845

It looks like during the refactor I missed off setting the versions to `latest` when called from an upgrade tests 🤦 

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

I'm going to skip the tests as they don't run against upgrades from this repo.