### PR TITLE
Fix ingress test for private CAPA clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Try and use ingress nginx app's config if present.
 - Enable ingress test for private CAPA test.
 
+### Fixed
+
+- In environments where an egress proxy exists, don't use 8.8.8.8 as a DNS resolver for the ingress test as that would prevent the proxy address from being resolved.
+
 ## [1.27.0] - 2024-02-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump Go version `v1.21` for teleport connectivity test
+- Bump Go version `v1.21` for teleport connectivity test.
+
+### Added
+
+- Try and use ingress nginx app's config if present.
+- Enable ingress test for private CAPA test.
 
 ## [1.27.0] - 2024-02-14
 

--- a/internal/common/hello.go
+++ b/internal/common/hello.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/cluster-test-suites/internal/helper"
 	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
 
@@ -69,6 +70,12 @@ func runHelloWorld(externalDnsSupported bool) {
 				WithClusterName(state.GetCluster().Name).
 				WithInCluster(false).
 				WithInstallNamespace("kube-system")
+
+			// check if ./test_data/ingress-nginx_values.yaml exists
+			path := "./test_data/ingress-nginx_values.yaml"
+			if helper.FileExists(path) {
+				nginxApp = nginxApp.MustWithValuesFile(path, &application.TemplateValues{})
+			}
 
 			err := state.GetFramework().MC().DeployApp(state.GetContext(), *nginxApp)
 			Expect(err).To(BeNil())

--- a/internal/helper/fileexists.go
+++ b/internal/helper/fileexists.go
@@ -1,0 +1,13 @@
+package helper
+
+import (
+	"os"
+)
+
+func FileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/providers/capa/private/capa_test.go
+++ b/providers/capa/private/capa_test.go
@@ -10,6 +10,6 @@ var _ = Describe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		AutoScalingSupported: true,
 		BastionSupported:     false,
-		ExternalDnsSupported: false,
+		ExternalDnsSupported: true,
 	})
 })

--- a/providers/capa/private/test_data/default-apps_values.yaml
+++ b/providers/capa/private/test_data/default-apps_values.yaml
@@ -2,18 +2,18 @@ clusterName: "{{ .ClusterName }}"
 organization: "{{ .Organization }}"
 userConfig:
   certManager:
-      configMap:
-        values:
-          serviceAccount:
-            annotations:
-              eks.amazonaws.com/role-arn: "{{ .ClusterName }}-Route53Manager-Role"
-          cert-manager-giantswarm-clusterissuer:
-            acme:
-              http01:
-                enabled: false
-              dns01:
-                route53:
-                  enabled: true
-                  # TODO Use a variable as soon as it is available.
-                  region: "eu-north-1"
-                  role: "{{ .ClusterName }}-Route53Manager-Role"
+    configMap:
+      values:
+        serviceAccount:
+          annotations:
+            eks.amazonaws.com/role-arn: "{{ .ClusterName }}-Route53Manager-Role"
+        giantSwarmClusterIssuer:
+          acme:
+            http01:
+              enabled: false
+            dns01:
+              route53:
+                enabled: true
+                # TODO Use a variable as soon as it is available.
+                region: "eu-north-1"
+                role: "{{ .ClusterName }}-Route53Manager-Role"

--- a/providers/capa/private/test_data/default-apps_values.yaml
+++ b/providers/capa/private/test_data/default-apps_values.yaml
@@ -1,2 +1,19 @@
 clusterName: "{{ .ClusterName }}"
 organization: "{{ .Organization }}"
+userConfig:
+  certManager:
+      configMap:
+        values:
+          serviceAccount:
+            annotations:
+              eks.amazonaws.com/role-arn: "{{ .ClusterName }}-Route53Manager-Role"
+          cert-manager-giantswarm-clusterissuer:
+            acme:
+              http01:
+                enabled: false
+              dns01:
+                route53:
+                  enabled: true
+                  # TODO Use a variable as soon as it is available.
+                  region: "eu-north-1"
+                  role: "{{ .ClusterName }}-Route53Manager-Role"

--- a/providers/capa/private/test_data/default-apps_values.yaml
+++ b/providers/capa/private/test_data/default-apps_values.yaml
@@ -17,4 +17,3 @@ userConfig:
                 enabled: true
                 # TODO Use a variable as soon as it is available.
                 region: "eu-north-1"
-                role: "{{ .ClusterName }}-CertManager-Role"

--- a/providers/capa/private/test_data/default-apps_values.yaml
+++ b/providers/capa/private/test_data/default-apps_values.yaml
@@ -5,6 +5,7 @@ userConfig:
     configMap:
       values:
         serviceAccount:
+          # capa iam operator wants the service account to be named like this for IRSA to work
           name: cert-manager-controller
           annotations:
             eks.amazonaws.com/role-arn: "{{ .ClusterName }}-CertManager-Role"

--- a/providers/capa/private/test_data/default-apps_values.yaml
+++ b/providers/capa/private/test_data/default-apps_values.yaml
@@ -6,7 +6,7 @@ userConfig:
       values:
         serviceAccount:
           annotations:
-            eks.amazonaws.com/role-arn: "{{ .ClusterName }}-Route53Manager-Role"
+            eks.amazonaws.com/role-arn: "{{ .ClusterName }}-CertManager-Role"
         giantSwarmClusterIssuer:
           acme:
             http01:
@@ -16,4 +16,4 @@ userConfig:
                 enabled: true
                 # TODO Use a variable as soon as it is available.
                 region: "eu-north-1"
-                role: "{{ .ClusterName }}-Route53Manager-Role"
+                role: "{{ .ClusterName }}-CertManager-Role"

--- a/providers/capa/private/test_data/default-apps_values.yaml
+++ b/providers/capa/private/test_data/default-apps_values.yaml
@@ -5,8 +5,6 @@ userConfig:
     configMap:
       values:
         serviceAccount:
-          # capa iam operator wants the service account to be named like this for IRSA to work
-          name: cert-manager-controller
           annotations:
             eks.amazonaws.com/role-arn: "{{ .ClusterName }}-CertManager-Role"
         giantSwarmClusterIssuer:

--- a/providers/capa/private/test_data/default-apps_values.yaml
+++ b/providers/capa/private/test_data/default-apps_values.yaml
@@ -5,6 +5,7 @@ userConfig:
     configMap:
       values:
         serviceAccount:
+          name: cert-manager-controller
           annotations:
             eks.amazonaws.com/role-arn: "{{ .ClusterName }}-CertManager-Role"
         giantSwarmClusterIssuer:

--- a/providers/capa/private/test_data/ingress-nginx_values.yaml
+++ b/providers/capa/private/test_data/ingress-nginx_values.yaml
@@ -5,4 +5,7 @@ controller:
       enabled: false
     internal:
       enabled: true
+      # We need to reuse the external subdomain for the internal service because dns-operator-route53 creates
+      # a wildcard record pointing towards ingress.<blah> domain.
+      subdomain: ingress
 

--- a/providers/capa/private/test_data/ingress-nginx_values.yaml
+++ b/providers/capa/private/test_data/ingress-nginx_values.yaml
@@ -1,0 +1,8 @@
+controller:
+  service:
+    enabled: true
+    external:
+      enabled: false
+    internal:
+      enabled: true
+


### PR DESCRIPTION
### What this PR does

Towards: https://github.com/giantswarm/roadmap/issues/3099

The ingress test for private capa clusters didn't work.
I needed to fix a few things here and there in order to make it run.
This PR is part of those fixes.

### Checklist

- [x] Update changelog in CHANGELOG.md.

