### PR TITLE
Rely on CAPV default values for k8s version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump Go version `v1.21` for teleport connectivity test
+- Update CAPV values and make more use of chart's default values
 
 ## [1.27.0] - 2024-02-14
 

--- a/providers/capv/standard/test_data/cluster_values.yaml
+++ b/providers/capv/standard/test_data/cluster_values.yaml
@@ -2,16 +2,12 @@ clusterDescription: "E2E Test cluster"
 organization: "{{ .Organization }}"
 
 baseDomain: test.gigantic.io
-cluster:
-  kubernetesVersion: "v1.24.11"
 
 controlPlane:
   replicas: 1
-  catalog: "giantswarm"
   image:
     repository: registry.k8s.io
   machineTemplate:
-    template: flatcar-stable-3602.2.1-kube-v1.24.12-gs
     cloneMode: "linkedClone"
     diskGiB: 50
     numCPUs: 4
@@ -23,20 +19,14 @@ controlPlane:
         dhcp4: true
 
 connectivity:
-  bastion:
-    enabled: true
   network:
     controlPlaneEndpoint:
-      host: ""  # [string] Manually select an IP for kube API. "" for auto selection from the ipPoolName pool.
-      port: 6443
       ipPoolName: "wc-cp-ips"  # [string] Ip for control plane will be drawn from this GlobalInClusterIPPool (for gcapeverde it's 10.10.222.232 - 10.10.222.238 inclusive)
     loadBalancers:
-      ipPoolName: "svc-lb-ips"  # [string] 1 ip for WC's kubevip will be drawn from this GlobalInClusterIPPool (for gcapeverde it's 10.10.222.245 - 10.10.222.249 inclusive)
-      cidrBlocks: []
+      ipPoolName: "svc-lb-ips" # [string] Ip for control plane will be drawn from this GlobalInClusterIPPool (for gcapeverde it's 10.10.222.245 - 10.10.222.249 inclusive)
 
 nodeClasses:
   default:
-    template: flatcar-stable-3602.2.1-kube-v1.24.12-gs
     cloneMode: "linkedClone"
     diskGiB: 50
     numCPUs: 6

--- a/providers/capv/upgrade/test_data/cluster_values.yaml
+++ b/providers/capv/upgrade/test_data/cluster_values.yaml
@@ -2,16 +2,12 @@ clusterDescription: "E2E Test cluster"
 organization: "{{ .Organization }}"
 
 baseDomain: test.gigantic.io
-cluster:
-  kubernetesVersion: "v1.24.11"
 
 controlPlane:
   replicas: 1
-  catalog: "giantswarm"
   image:
     repository: registry.k8s.io
   machineTemplate:
-    template: flatcar-stable-3602.2.1-kube-v1.24.12-gs
     cloneMode: "linkedClone"
     diskGiB: 50
     numCPUs: 4
@@ -23,21 +19,14 @@ controlPlane:
         dhcp4: true
 
 connectivity:
-  bastion:
-    enabled: true
   network:
-    allowAllEgress: true
     controlPlaneEndpoint:
-      host: ""  # [string] Manually select an IP for kube API. "" for auto selection from the ipPoolName pool.
-      port: 6443
       ipPoolName: "wc-cp-ips"  # [string] Ip for control plane will be drawn from this GlobalInClusterIPPool (for gcapeverde it's 10.10.222.232 - 10.10.222.238 inclusive)
     loadBalancers:
-      cidrBlocks:
-      - "10.10.222.239/32"
+      ipPoolName: "svc-lb-ips" # [string] Ip for control plane will be drawn from this GlobalInClusterIPPool (for gcapeverde it's 10.10.222.245 - 10.10.222.249 inclusive)
 
 nodeClasses:
   default:
-    template: flatcar-stable-3602.2.1-kube-v1.24.12-gs
     cloneMode: "linkedClone"
     diskGiB: 50
     numCPUs: 6


### PR DESCRIPTION
### What this PR does


### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
