### PR TITLE
Create results.json early when running standup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set app versions when using `standup` CLI
+- Create the `results.json` file as soon as possible when running `standup` in case the cluster creation fails to allows the `teardown` command to still use it.
+
 ## [1.30.0] - 2024-03-12
 
 ### Added


### PR DESCRIPTION
### What this PR does

* Ensures the provided app versions are passed to the cluster builder
* Created the `results.json` file as soon as possible so that if the cluster creation fails the `teardown` command still has a file to use to clean up the failed cluster.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

Skipping tests as this CLI isn't tested. Manual testing has been done.
