### PR TITLE
Disable EKS tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disabled EKS tests due to environment being broken
+
 ## [1.30.1] - 2024-03-14
 
 ### Fixed

--- a/providers/eks/standard/eks_test.go
+++ b/providers/eks/standard/eks_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = Describe("Common tests", func() {
+var _ = XDescribe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		AutoScalingSupported: true,
 		BastionSupported:     false,

--- a/providers/eks/upgrade/eks_test.go
+++ b/providers/eks/upgrade/eks_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
 )
 
-var _ = Describe("Basic upgrade test", Ordered, func() {
+var _ = XDescribe("Basic upgrade test", Ordered, func() {
 	upgrade.Run(upgrade.NewTestConfigWithDefaults())
 
 	// Finally run the common tests after upgrade is completed


### PR DESCRIPTION
### What this PR does

Marks the EKS tests as skipped as they are currently broken in `grizzly` and unlikely to be fixed in the next week or so.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

Skipping.