### PR TITLE
Increase cert-manager test timeout to 2 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase cert-manager test timeout to 2 minutes.
+
 ## [1.31.0] - 2024-03-14
 
 ### Changed

--- a/internal/common/certmanager.go
+++ b/internal/common/certmanager.go
@@ -34,7 +34,7 @@ func runCertManager() {
 		It("cert-manager default ClusterIssuers are present and ready", func() {
 			for _, clusterIssuerName := range clusterIssuers {
 				Eventually(checkClusterIssuer(wcClient, clusterIssuerName)).
-					WithTimeout(30 * time.Second).
+					WithTimeout(120 * time.Second).
 					WithPolling(1 * time.Second).
 					Should(Succeed())
 			}


### PR DESCRIPTION
### What this PR does

Increases the timeout when waiting for cert-manager to 2 minutes

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
