### PR TITLE
re-enable-eks-tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Increase cert-manager test timeout to 2 minutes.
+- Enabled EKS tests.
 
 ## [1.31.0] - 2024-03-14
 

--- a/providers/eks/standard/eks_test.go
+++ b/providers/eks/standard/eks_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = XDescribe("Common tests", func() {
+var _ = Describe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		AutoScalingSupported: true,
 		BastionSupported:     false,

--- a/providers/eks/upgrade/eks_test.go
+++ b/providers/eks/upgrade/eks_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
 )
 
-var _ = XDescribe("Basic upgrade test", Ordered, func() {
+var _ = Describe("Basic upgrade test", Ordered, func() {
 	upgrade.Run(upgrade.NewTestConfigWithDefaults())
 
 	// Finally run the common tests after upgrade is completed


### PR DESCRIPTION
enable EKS test at they are now on 1.25
/run cluster-test-suites
