### PR TITLE
Avoid checking control plane metrics in EKS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Increase cert-manager test timeout to 2 minutes.
 - Enabled EKS tests.
+- Avoid checking control plane metrics in EKS.
 
 ## [1.31.0] - 2024-03-14
 

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -1,10 +1,11 @@
 package common
 
 type TestConfig struct {
-	AutoScalingSupported bool
-	BastionSupported     bool
-	TeleportSupported    bool
-	ExternalDnsSupported bool
+	AutoScalingSupported         bool
+	BastionSupported             bool
+	TeleportSupported            bool
+	ExternalDnsSupported         bool
+	ControlPlaneMetricsSupported bool
 }
 
 func Run(cfg *TestConfig) {
@@ -12,7 +13,7 @@ func Run(cfg *TestConfig) {
 	runBasic()
 	runCertManager()
 	runDNS(cfg.BastionSupported)
-	runMetrics()
+	runMetrics(cfg.ControlPlaneMetricsSupported)
 	runTeleport(cfg.TeleportSupported)
 	runHelloWorld(cfg.ExternalDnsSupported)
 	runScale(cfg.AutoScalingSupported)

--- a/internal/common/metrics.go
+++ b/internal/common/metrics.go
@@ -15,7 +15,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
 
-func runMetrics() {
+func runMetrics(controlPlaneMetricsSupported bool) {
 	Context("metrics", func() {
 		var mcClient *client.Client
 		var metrics []string
@@ -25,32 +25,10 @@ func runMetrics() {
 
 			// List of metrics that must be present.
 			metrics = []string{
-				// API server metrics in prometheus-rules
-				"apiserver_flowcontrol_dispatched_requests_total",
-				"apiserver_flowcontrol_request_concurrency_limit",
-				"apiserver_request_duration_seconds_bucket",
-				"apiserver_admission_webhook_request_total",
-				"apiserver_admission_webhook_admission_duration_seconds_sum",
-				"apiserver_admission_webhook_admission_duration_seconds_count",
-				"apiserver_request_total",
-				"apiserver_audit_event_total",
-
 				// Kubelet
 				"kube_node_status_condition",
 				"kube_node_spec_unschedulable",
 				"kube_node_created",
-
-				// Controller manager
-				"workqueue_queue_duration_seconds_count",
-				"workqueue_queue_duration_seconds_bucket",
-
-				// Scheduler
-				"scheduler_pod_scheduling_duration_seconds_count",
-				"scheduler_pod_scheduling_duration_seconds_bucket",
-
-				// ETCD
-				"etcd_request_duration_seconds_count",
-				"etcd_request_duration_seconds_bucket",
 
 				// Coredns
 				"coredns_dns_request_duration_seconds_count",
@@ -58,6 +36,32 @@ func runMetrics() {
 
 				// Net exporter
 				"network_latency_seconds_sum",
+			}
+
+			if controlPlaneMetricsSupported {
+				metrics = append(metrics, []string{
+					// API server metrics in prometheus-rules
+					"apiserver_flowcontrol_dispatched_requests_total",
+					"apiserver_flowcontrol_request_concurrency_limit",
+					"apiserver_request_duration_seconds_bucket",
+					"apiserver_admission_webhook_request_total",
+					"apiserver_admission_webhook_admission_duration_seconds_sum",
+					"apiserver_admission_webhook_admission_duration_seconds_count",
+					"apiserver_request_total",
+					"apiserver_audit_event_total",
+
+					// Controller manager
+					"workqueue_queue_duration_seconds_count",
+					"workqueue_queue_duration_seconds_bucket",
+
+					// Scheduler
+					"scheduler_pod_scheduling_duration_seconds_count",
+					"scheduler_pod_scheduling_duration_seconds_bucket",
+
+					// ETCD
+					"etcd_request_duration_seconds_count",
+					"etcd_request_duration_seconds_bucket",
+				}...)
 			}
 		})
 

--- a/providers/capa/private/capa_test.go
+++ b/providers/capa/private/capa_test.go
@@ -8,9 +8,10 @@ import (
 
 var _ = Describe("Common tests", func() {
 	common.Run(&common.TestConfig{
-		AutoScalingSupported: true,
-		BastionSupported:     false,
-		TeleportSupported:    true,
-		ExternalDnsSupported: true,
+		AutoScalingSupported:         true,
+		BastionSupported:             false,
+		TeleportSupported:            true,
+		ExternalDnsSupported:         true,
+		ControlPlaneMetricsSupported: true,
 	})
 })

--- a/providers/capa/standard/capa_test.go
+++ b/providers/capa/standard/capa_test.go
@@ -8,9 +8,10 @@ import (
 
 var _ = Describe("Common tests", func() {
 	common.Run(&common.TestConfig{
-		AutoScalingSupported: true,
-		BastionSupported:     false,
-		TeleportSupported:    true,
-		ExternalDnsSupported: true,
+		AutoScalingSupported:         true,
+		BastionSupported:             false,
+		TeleportSupported:            true,
+		ExternalDnsSupported:         true,
+		ControlPlaneMetricsSupported: true,
 	})
 })

--- a/providers/capa/upgrade/capa_test.go
+++ b/providers/capa/upgrade/capa_test.go
@@ -12,9 +12,10 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 
 	// Finally run the common tests after upgrade is completed
 	common.Run(&common.TestConfig{
-		AutoScalingSupported: true,
-		BastionSupported:     false,
-		TeleportSupported:    true,
-		ExternalDnsSupported: true,
+		AutoScalingSupported:         true,
+		BastionSupported:             false,
+		TeleportSupported:            true,
+		ExternalDnsSupported:         true,
+		ControlPlaneMetricsSupported: true,
 	})
 })

--- a/providers/capv/standard/capv_test.go
+++ b/providers/capv/standard/capv_test.go
@@ -13,6 +13,7 @@ var _ = Describe("Common tests", func() {
 		BastionSupported:     false,
 		TeleportSupported:    true,
 		// Disabled until https://github.com/giantswarm/roadmap/issues/1037
-		ExternalDnsSupported: false,
+		ExternalDnsSupported:         false,
+		ControlPlaneMetricsSupported: true,
 	})
 })

--- a/providers/capv/upgrade/capv_test.go
+++ b/providers/capv/upgrade/capv_test.go
@@ -17,6 +17,7 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 		BastionSupported:     false,
 		TeleportSupported:    true,
 		// Disabled until https://github.com/giantswarm/roadmap/issues/1037
-		ExternalDnsSupported: false,
+		ExternalDnsSupported:         false,
+		ControlPlaneMetricsSupported: true,
 	})
 })

--- a/providers/capvcd/standard/capvcd_test.go
+++ b/providers/capvcd/standard/capvcd_test.go
@@ -13,6 +13,7 @@ var _ = Describe("Common tests", func() {
 		BastionSupported:     false,
 		TeleportSupported:    true,
 		// Disabled until https://github.com/giantswarm/roadmap/issues/1037
-		ExternalDnsSupported: false,
+		ExternalDnsSupported:         false,
+		ControlPlaneMetricsSupported: true,
 	})
 })

--- a/providers/capvcd/upgrade/capvcd_test.go
+++ b/providers/capvcd/upgrade/capvcd_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 		BastionSupported:     false,
 		TeleportSupported:    true,
 		// Disabled until https://github.com/giantswarm/roadmap/issues/1037
-		ExternalDnsSupported: false,
+		ExternalDnsSupported:         false,
+		ControlPlaneMetricsSupported: true,
 	})
 })

--- a/providers/capz/standard/capz_test.go
+++ b/providers/capz/standard/capz_test.go
@@ -20,6 +20,7 @@ var _ = Describe("Common tests", func() {
 		BastionSupported:     false,
 		TeleportSupported:    true,
 		// Disabled until wildcard ingress support is added
-		ExternalDnsSupported: false,
+		ExternalDnsSupported:         false,
+		ControlPlaneMetricsSupported: true,
 	})
 })

--- a/providers/capz/upgrade/capz_test.go
+++ b/providers/capz/upgrade/capz_test.go
@@ -17,6 +17,7 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 		BastionSupported:     false,
 		TeleportSupported:    true,
 		// Disabled until wildcard ingress support is added
-		ExternalDnsSupported: false,
+		ExternalDnsSupported:         false,
+		ControlPlaneMetricsSupported: true,
 	})
 })

--- a/providers/eks/standard/eks_test.go
+++ b/providers/eks/standard/eks_test.go
@@ -11,5 +11,7 @@ var _ = Describe("Common tests", func() {
 		AutoScalingSupported: true,
 		BastionSupported:     false,
 		ExternalDnsSupported: true,
+		// EKS does not have metrics for k8s control plane components.
+		ControlPlaneMetricsSupported: false,
 	})
 })

--- a/providers/eks/upgrade/eks_test.go
+++ b/providers/eks/upgrade/eks_test.go
@@ -15,5 +15,7 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 		AutoScalingSupported: true,
 		BastionSupported:     false,
 		ExternalDnsSupported: true,
+		// EKS does not have metrics for k8s control plane components.
+		ControlPlaneMetricsSupported: false,
 	})
 })


### PR DESCRIPTION
### What this PR does

avoid checking presence of k8s control plane metrics in eks


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
