### PR TITLE
Increase cluster creation timeout to 30 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase cluster creation timeout to 30 minutes.
+
 ## [1.32.0] - 2024-03-20
 
 ### Changed

--- a/cmd/standup/main.go
+++ b/cmd/standup/main.go
@@ -142,7 +142,7 @@ func run(cmd *cobra.Command, args []string) error {
 	resultsFile.Close()
 
 	// Apply cluster App
-	applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 20*time.Minute)
+	applyCtx, cancelApplyCtx := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancelApplyCtx()
 
 	wcClient, err := framework.ApplyCluster(applyCtx, cluster)


### PR DESCRIPTION
### What this PR does

Increases the cluster creation timeout to try and avoid test flakes caused by slow infra.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
