### PR TITLE
Increase cert-manager test timeout to 15 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Increase cluster creation timeout to 30 minutes.
 - Switch CAPVCD values to 1.25.13.
+- Increase cert-manager test timeout to 15 minutes.
 
 ## [1.32.0] - 2024-03-20
 

--- a/internal/common/certmanager.go
+++ b/internal/common/certmanager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/state"
 	"github.com/giantswarm/clustertest/pkg/client"
 	"github.com/giantswarm/clustertest/pkg/logger"
+	"github.com/giantswarm/clustertest/pkg/wait"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	cr "sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/common/certmanager.go
+++ b/internal/common/certmanager.go
@@ -34,8 +34,8 @@ func runCertManager() {
 		It("cert-manager default ClusterIssuers are present and ready", func() {
 			for _, clusterIssuerName := range clusterIssuers {
 				Eventually(checkClusterIssuer(wcClient, clusterIssuerName)).
-					WithTimeout(120 * time.Second).
-					WithPolling(1 * time.Second).
+					WithTimeout(15 * time.Minute).
+					WithPolling(wait.DefaultInterval).
 					Should(Succeed())
 			}
 		})


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30364

### What this PR does
- Increases the timeout when waiting for cert-manager to 15 minutes.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
