### PR TITLE
Include the MC endpoint in log message to indeicate which MC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Include the MCs api endpoint when logging out the "checking connection to MC" message
+
 ## [1.33.0] - 2024-03-28
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.1
-	github.com/giantswarm/clustertest v0.16.0
+	github.com/giantswarm/clustertest v0.17.0
 	github.com/gravitational/teleport/api v0.0.0-20240221014947-7cec562a5fe2
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
@@ -79,7 +79,7 @@ require (
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/go-github/v59 v59.0.0 // indirect
+	github.com/google/go-github/v61 v61.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20230406165453-00490a63f317 // indirect

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkPJa+rXKBr9e0p+6nd8aw3A=
 github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/clustertest v0.16.0 h1:LsKNI4/WdLQcy3l34tZJCFIZ9YTJDrxeg520za/a2fE=
-github.com/giantswarm/clustertest v0.16.0/go.mod h1:9YyuOBncn4jHVDa9TRrN5IA/a62NyqBHX1p5VZk8i14=
+github.com/giantswarm/clustertest v0.17.0 h1:xZ6sLEqQp3sGKUb1phVitPyZiTOTnzWSgmR2wKyZBe0=
+github.com/giantswarm/clustertest v0.17.0/go.mod h1:IJyeWqFp36ECDPCbbluUThL8YAq4ZG+xir+MZhWoE6g=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=
 github.com/giantswarm/k8smetadata v0.23.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.45.0 h1:4g1Fnpkf4gjxiZtFPCEIfEnEWVIpoTXj1yij4hxaOok=
@@ -364,8 +364,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v59 v59.0.0 h1:7h6bgpF5as0YQLLkEiVqpgtJqjimMYhBkD4jT5aN3VA=
-github.com/google/go-github/v59 v59.0.0/go.mod h1:rJU4R0rQHFVFDOkqGWxfLNo6vEk4dv40oDjhV/gH6wM=
+github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5pNlu1go=
+github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/internal/suite/setup.go
+++ b/internal/suite/setup.go
@@ -47,7 +47,7 @@ func Setup(isUpgrade bool, kubeContext string, clusterBuilder ClusterBuilder, cl
 		// isn't ready and can take a short while to become usable. This attempts to wait
 		// for the connection to be usable before starting the tests.
 		Eventually(func() error {
-			logger.Log("Checking connection to MC is available")
+			logger.Log("Checking connection to MC is available. API Endpoint: %s", framework.MC().GetAPIServerEndpoint())
 			return framework.MC().CheckConnection()
 		}).
 			WithTimeout(5 * time.Minute).

--- a/internal/suite/setup.go
+++ b/internal/suite/setup.go
@@ -47,7 +47,9 @@ func Setup(isUpgrade bool, kubeContext string, clusterBuilder ClusterBuilder, cl
 		// isn't ready and can take a short while to become usable. This attempts to wait
 		// for the connection to be usable before starting the tests.
 		Eventually(func() error {
-			logger.Log("Checking connection to MC is available. API Endpoint: %s", framework.MC().GetAPIServerEndpoint())
+			logger.Log("Checking connection to MC is available.")
+			logger.Log("MC API Endpoint: '%s'", framework.MC().GetAPIServerEndpoint())
+			logger.Log("MC name: '%s'", framework.MC().GetClusterName())
 			return framework.MC().CheckConnection()
 		}).
 			WithTimeout(5 * time.Minute).


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/giantswarm/giantswarm/issues/30298

Include the MCs API server endpoint in the log output to make it clear which cluster we are running the tests against.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
