### PR TITLE
switch capvcd to flatcar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Include the MCs api endpoint when logging out the "checking connection to MC" message
 
+### Changed
+
+- Switch CAPVCD to Flatcar (1.25.16).
+
 ## [1.33.0] - 2024-03-28
 
 ### Changed

--- a/providers/capvcd/standard/test_data/cluster_values.yaml
+++ b/providers/capvcd/standard/test_data/cluster_values.yaml
@@ -1,4 +1,3 @@
-
 baseDomain: test.gigantic.io
 controlPlane:
   catalog: giantswarm
@@ -6,7 +5,15 @@ controlPlane:
   # https://github.com/giantswarm/giantswarm/issues/29353
   replicas: 1
   sizingPolicy: m1.large
-  template: ubuntu-2004-kube-v1.25.13
+  template: flatcar-stable-3602.2.1-kube-v1.25.16
+  dns:
+    imageRepository: gsoci.azurecr.io/giantswarm
+    imageTag: 1.9.4-giantswarm
+  etcd:
+    imageRepository: gsoci.azurecr.io/giantswarm
+    imageTag: 3.5.12-0-k8s
+  image:
+    repository: gsoci.azurecr.io/giantswarm
   oidc:
     clientId: "dex-k8s-authenticator"
     groupsClaim: "groups"
@@ -30,11 +37,12 @@ providerSpecific:
   ovdc: Org-GIANT-SWARM
   site: "https://cd.neoedge.cloud"
   ovdcNetwork: GS-ISOLATED
+  vmBootstrapFormat: ignition
   nodeClasses:
     default:
       catalog: giantswarm
       sizingPolicy: m1.large
-      template: ubuntu-2004-kube-v1.25.13
+      template: flatcar-stable-3602.2.1-kube-v1.25.16
   userContext:
     secretRef:
       secretName: vcd-credentials
@@ -42,4 +50,4 @@ metadata:
   description: "E2E Test cluster"
   organization: "{{ .Organization }}"
 internal:
-  kubernetesVersion: v1.25.13+vmware.1
+  kubernetesVersion: v1.25.16

--- a/providers/capvcd/standard/test_data/cluster_values.yaml
+++ b/providers/capvcd/standard/test_data/cluster_values.yaml
@@ -6,12 +6,6 @@ controlPlane:
   replicas: 1
   sizingPolicy: m1.large
   template: flatcar-stable-3602.2.1-kube-v1.25.16
-  dns:
-    imageRepository: gsoci.azurecr.io/giantswarm
-    imageTag: 1.9.4-giantswarm
-  etcd:
-    imageRepository: gsoci.azurecr.io/giantswarm
-    imageTag: 3.5.12-0-k8s
   image:
     repository: gsoci.azurecr.io/giantswarm
   oidc:

--- a/providers/capvcd/upgrade/test_data/cluster_values.yaml
+++ b/providers/capvcd/upgrade/test_data/cluster_values.yaml
@@ -5,7 +5,15 @@ controlPlane:
   # https://github.com/giantswarm/giantswarm/issues/29353
   replicas: 1
   sizingPolicy: m1.large
-  template: ubuntu-2004-kube-v1.25.13
+  template: flatcar-stable-3602.2.1-kube-v1.25.16
+  dns:
+    imageRepository: gsoci.azurecr.io/giantswarm
+    imageTag: 1.9.4-giantswarm
+  etcd:
+    imageRepository: gsoci.azurecr.io/giantswarm
+    imageTag: 3.5.12-0-k8s
+  image:
+    repository: gsoci.azurecr.io/giantswarm
   oidc:
     clientId: "dex-k8s-authenticator"
     groupsClaim: "groups"
@@ -29,11 +37,12 @@ providerSpecific:
   ovdc: Org-GIANT-SWARM
   site: "https://cd.neoedge.cloud"
   ovdcNetwork: GS-ISOLATED
+  vmBootstrapFormat: ignition
   nodeClasses:
     default:
       catalog: giantswarm
       sizingPolicy: m1.large
-      template: ubuntu-2004-kube-v1.25.13
+      template: flatcar-stable-3602.2.1-kube-v1.25.16
   userContext:
     secretRef:
       secretName: vcd-credentials
@@ -41,4 +50,4 @@ metadata:
   description: "E2E Test cluster"
   organization: "{{ .Organization }}"
 internal:
-  kubernetesVersion: v1.25.13+vmware.1
+  kubernetesVersion: v1.25.16

--- a/providers/capvcd/upgrade/test_data/cluster_values.yaml
+++ b/providers/capvcd/upgrade/test_data/cluster_values.yaml
@@ -6,12 +6,6 @@ controlPlane:
   replicas: 1
   sizingPolicy: m1.large
   template: flatcar-stable-3602.2.1-kube-v1.25.16
-  dns:
-    imageRepository: gsoci.azurecr.io/giantswarm
-    imageTag: 1.9.4-giantswarm
-  etcd:
-    imageRepository: gsoci.azurecr.io/giantswarm
-    imageTag: 3.5.12-0-k8s
   image:
     repository: gsoci.azurecr.io/giantswarm
   oidc:


### PR DESCRIPTION
### What this PR does

Switches the CAPVCD tests to use Flatcar as the base OS.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
