### PR TITLE
Add support for mimir in the `metrics` test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for mimir in the `metrics` test.
+
 ## [1.34.0] - 2024-04-04
 
 ### Added

--- a/internal/common/metrics.go
+++ b/internal/common/metrics.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/giantswarm/clustertest/pkg/client"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	. "github.com/onsi/ginkgo/v2"
@@ -156,6 +155,9 @@ func checkMetricPresent(mcClient *client.Client, metric string, prometheusBaseUr
 }
 
 func runTestPod(mcClient *client.Client, podName string, ns string) error {
+	t := true
+	f := false
+
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
@@ -163,7 +165,7 @@ func runTestPod(mcClient *client.Client, podName string, ns string) error {
 		},
 		Spec: corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: to.BoolPtr(true),
+				RunAsNonRoot: &t,
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: "RuntimeDefault",
 				},
@@ -179,7 +181,7 @@ func runTestPod(mcClient *client.Client, podName string, ns string) error {
 								"ALL",
 							},
 						},
-						AllowPrivilegeEscalation: to.BoolPtr(false),
+						AllowPrivilegeEscalation: &f,
 					},
 				},
 			},

--- a/internal/common/metrics.go
+++ b/internal/common/metrics.go
@@ -71,7 +71,9 @@ func runMetrics(controlPlaneMetricsSupported bool) {
 					"etcd_request_duration_seconds_bucket",
 				}...)
 			}
+		})
 
+		It("creates test pod", func() {
 			// Run a pod with alpine in the default namespace of the MC.
 			testPodName = fmt.Sprintf("%s-metrics-test", state.GetCluster().Name)
 			testPodNamespace = "default"
@@ -83,11 +85,6 @@ func runMetrics(controlPlaneMetricsSupported bool) {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		AfterAll(func() {
-			err := cleanupTestPod(mcClient, testPodName, testPodNamespace)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
 		It("ensure key metrics are available on prometheus", func() {
 			for _, metric := range metrics {
 				Eventually(checkMetricPresent(mcClient, metric, prometheusBaseUrl, testPodName, testPodNamespace)).
@@ -95,6 +92,11 @@ func runMetrics(controlPlaneMetricsSupported bool) {
 					WithPolling(10 * time.Second).
 					Should(Succeed())
 			}
+		})
+
+		It("clean up test pod", func() {
+			err := cleanupTestPod(mcClient, testPodName, testPodNamespace)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 }

--- a/internal/common/metrics.go
+++ b/internal/common/metrics.go
@@ -159,6 +159,7 @@ func checkMetricPresent(mcClient *client.Client, metric string, prometheusBaseUr
 func runTestPod(mcClient *client.Client, podName string, ns string) error {
 	t := true
 	f := false
+	userAndGroup := int64(35)
 
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -167,6 +168,8 @@ func runTestPod(mcClient *client.Client, podName string, ns string) error {
 		},
 		Spec: corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser:    &userAndGroup,
+				RunAsGroup:   &userAndGroup,
 				RunAsNonRoot: &t,
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: "RuntimeDefault",

--- a/internal/helper/prometheus.go
+++ b/internal/helper/prometheus.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/clustertest/pkg/client"
+	"github.com/giantswarm/clustertest/pkg/logger"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,12 +25,15 @@ func DetectPrometheusBaseURL(ctx context.Context, mcClient *client.Client) (stri
 
 	err := mcClient.Get(ctx, ctrlclient.ObjectKey{Namespace: mimirNamespace, Name: mimirGatewayService}, svc)
 	if errors.IsNotFound(err) {
+		logger.Log("Legacy prometheus setup detected")
 		// Mimir service not found, we assume it's the old Prometheus setup.
 		return fmt.Sprintf("prometheus-operated.%[1]s-prometheus:9090/%[1]s", state.GetCluster().Name), nil
 	} else if err != nil {
 		// Generic error.
 		return "", err
 	}
+
+	logger.Log("Mimir detected")
 
 	// Mimir service found, we use it.
 	return fmt.Sprintf("%s.%s:%d/prometheus", mimirGatewayService, mimirNamespace, svc.Spec.Ports[0].Port), nil

--- a/internal/helper/prometheus.go
+++ b/internal/helper/prometheus.go
@@ -1,0 +1,36 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/clustertest/pkg/client"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/cluster-test-suites/internal/state"
+)
+
+const (
+	mimirNamespace      = "mimir"
+	mimirGatewayService = "mimir-gateway"
+)
+
+// DetectPrometheusBaseURL checks if the MC is running old Prometheus setup or mimir and returns the base URL to send PROMQL queries to.
+func DetectPrometheusBaseURL(ctx context.Context, mcClient *client.Client) (string, error) {
+	// Check if there is a Service named 'mimir-gateway' in the namespace 'mimir'.
+	svc := &corev1.Service{}
+
+	err := mcClient.Get(ctx, ctrlclient.ObjectKey{Namespace: mimirNamespace, Name: mimirGatewayService}, svc)
+	if errors.IsNotFound(err) {
+		// Mimir service not found, we assume it's the old Prometheus setup.
+		return fmt.Sprintf("prometheus-operated.%[1]s-prometheus:9090/%[1]s", state.GetCluster().Name), nil
+	} else if err != nil {
+		// Generic error.
+		return "", err
+	}
+
+	// Mimir service found, we use it.
+	return fmt.Sprintf("%s.%s:%d/prometheus", mimirGatewayService, mimirNamespace, svc.Spec.Ports[0].Port), nil
+}


### PR DESCRIPTION
### What this PR does

Towards:

https://github.com/giantswarm/giantswarm/issues/30424

adds support for mimir to the `metrics` test.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
