### PR TITLE
CAPVCD: re-enable HA CP with 3 nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Revert #169 by increasing CAPVCD CP nodes back to 3.
+
 ## [1.35.0] - 2024-04-08
 
 ### Added

--- a/providers/capvcd/standard/test_data/cluster_values.yaml
+++ b/providers/capvcd/standard/test_data/cluster_values.yaml
@@ -1,9 +1,7 @@
 baseDomain: test.gigantic.io
 controlPlane:
   catalog: giantswarm
-  # HA is disabled temporarily due to
-  # https://github.com/giantswarm/giantswarm/issues/29353
-  replicas: 1
+  replicas: 3
   sizingPolicy: m1.large
   template: flatcar-stable-3602.2.1-kube-v1.25.16
   image:

--- a/providers/capvcd/upgrade/test_data/cluster_values.yaml
+++ b/providers/capvcd/upgrade/test_data/cluster_values.yaml
@@ -1,9 +1,7 @@
 baseDomain: test.gigantic.io
 controlPlane:
   catalog: giantswarm
-  # HA is disabled temporarily due to
-  # https://github.com/giantswarm/giantswarm/issues/29353
-  replicas: 1
+  replicas: 3
   sizingPolicy: m1.large
   template: flatcar-stable-3602.2.1-kube-v1.25.16
   image:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/29353

### What this PR does

- Increase CAPVCD CP node count to 3.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
