### PR TITLE
use default values of cluster-cloud-director chart:v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Revert #169 by increasing CAPVCD CP nodes back to 3.
+- Use default values of `cluster-cloud-director chart:v0.50.0`.
 
 ## [1.35.0] - 2024-04-08
 

--- a/providers/capvcd/standard/test_data/cluster_values.yaml
+++ b/providers/capvcd/standard/test_data/cluster_values.yaml
@@ -1,6 +1,7 @@
 baseDomain: test.gigantic.io
 controlPlane:
   replicas: 3
+  diskSizeGB: 30
   sizingPolicy: m1.large
   oidc:
     clientId: "dex-k8s-authenticator"
@@ -28,6 +29,7 @@ providerSpecific:
   nodeClasses:
     default:
       sizingPolicy: m1.large
+      diskSizeGB: 30
   userContext:
     secretRef:
       secretName: vcd-credentials

--- a/providers/capvcd/standard/test_data/cluster_values.yaml
+++ b/providers/capvcd/standard/test_data/cluster_values.yaml
@@ -1,11 +1,7 @@
 baseDomain: test.gigantic.io
 controlPlane:
-  catalog: giantswarm
   replicas: 3
   sizingPolicy: m1.large
-  template: flatcar-stable-3602.2.1-kube-v1.25.16
-  image:
-    repository: gsoci.azurecr.io/giantswarm
   oidc:
     clientId: "dex-k8s-authenticator"
     groupsClaim: "groups"
@@ -29,17 +25,12 @@ providerSpecific:
   ovdc: Org-GIANT-SWARM
   site: "https://cd.neoedge.cloud"
   ovdcNetwork: GS-ISOLATED
-  vmBootstrapFormat: ignition
   nodeClasses:
     default:
-      catalog: giantswarm
       sizingPolicy: m1.large
-      template: flatcar-stable-3602.2.1-kube-v1.25.16
   userContext:
     secretRef:
       secretName: vcd-credentials
 metadata:
   description: "E2E Test cluster"
   organization: "{{ .Organization }}"
-internal:
-  kubernetesVersion: v1.25.16

--- a/providers/capvcd/upgrade/test_data/cluster_values.yaml
+++ b/providers/capvcd/upgrade/test_data/cluster_values.yaml
@@ -2,6 +2,7 @@ baseDomain: test.gigantic.io
 controlPlane:
   replicas: 3
   sizingPolicy: m1.large
+  diskSizeGB: 30
   oidc:
     clientId: "dex-k8s-authenticator"
     groupsClaim: "groups"
@@ -27,6 +28,7 @@ providerSpecific:
   ovdcNetwork: GS-ISOLATED
   nodeClasses:
     default:
+      diskSizeGB: 30
       sizingPolicy: m1.large
   userContext:
     secretRef:

--- a/providers/capvcd/upgrade/test_data/cluster_values.yaml
+++ b/providers/capvcd/upgrade/test_data/cluster_values.yaml
@@ -1,11 +1,7 @@
 baseDomain: test.gigantic.io
 controlPlane:
-  catalog: giantswarm
   replicas: 3
   sizingPolicy: m1.large
-  template: flatcar-stable-3602.2.1-kube-v1.25.16
-  image:
-    repository: gsoci.azurecr.io/giantswarm
   oidc:
     clientId: "dex-k8s-authenticator"
     groupsClaim: "groups"
@@ -29,17 +25,12 @@ providerSpecific:
   ovdc: Org-GIANT-SWARM
   site: "https://cd.neoedge.cloud"
   ovdcNetwork: GS-ISOLATED
-  vmBootstrapFormat: ignition
   nodeClasses:
     default:
-      catalog: giantswarm
       sizingPolicy: m1.large
-      template: flatcar-stable-3602.2.1-kube-v1.25.16
   userContext:
     secretRef:
       secretName: vcd-credentials
 metadata:
   description: "E2E Test cluster"
   organization: "{{ .Organization }}"
-internal:
-  kubernetesVersion: v1.25.16


### PR DESCRIPTION
### What this PR does

In `cluster-cloud-director` `v0.50.0`, we move to a release model where K8s version and VM template are set in default values to be controlled by Giant Swarm through cluster app versions.

Towards https://github.com/giantswarm/roadmap/issues/3392

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
