### PR TITLE
Update example kubeconfig in README for CAPVCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ contexts:
     user: gcapeverde-admin
   name: capv
 - context:
-    cluster: guppy
-    user: guppy-admin
+    cluster: gerbil
+    user: gerbil-admin
   name: capvcd
 clusters:
 - cluster:
@@ -52,7 +52,7 @@ clusters:
 - cluster:
     certificate-authority-data: [REDACTED]
     server: https://[REDACTED]:6443
-  name: guppy
+  name: gerbil
 current-context: grizzly
 preferences: {}
 users:
@@ -68,7 +68,7 @@ users:
   user:
     client-certificate-data: [REDACTED]
     client-key-data: [REDACTED]
-- name: guppy-admin
+- name: gerbil-admin
   user:
     client-certificate-data: [REDACTED]
     client-key-data: [REDACTED]


### PR DESCRIPTION
### What this PR does

- Updates example kubeconfig for CAPVCD to use `gerbil` as `guppy` is dead.

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
