### PR TITLE
Use KubeContext from cluster-standup-teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated cluster-standup-teardown to v1.0.2
+- Made use of new `clusterbuilder.KubeContext()` function
+- Updated readme requirements
+
+### Removed
+
+- Removed KubeContext const from each test suite
+
 ## [1.39.0] - 2024-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,76 +4,13 @@
 
 ## ☑️ Requirements
 
-* A valid Kubeconfig with the following context available:
-  * `capa` pointing to a valid CAPA MC
-  * `capz` pointing to a valid CAPZ MC
-  * `capv` pointing to a valid CAPV MC
-  * `capvcd` pointing to a valid CAPVCD MC
+* A valid Kubeconfig with the required context defined. (See [cluster-standup-teardown](https://github.com/giantswarm/cluster-standup-teardown) for more details.)
 * Install [ginkgo](https://onsi.github.io/ginkgo/) on your machine: `go install github.com/onsi/ginkgo/v2/ginkgo`.
 * The `E2E_KUBECONFIG` environment variable set to point to the path of the above kubeconfig.
+
+Optional:
 * When `E2E_WC_NAME` and `E2E_WC_NAMESPACE` environment variables are set, the tests will run against the specified WC on the targeted MC. If one or both of the variables isn't set, the tests will create their own WC.
 * When `TELEPORT_IDENTITY_FILE` environment variable is set to point to the path of a valid teleport credential, the test will check if E2E WC is registered in Teleport cluster (`teleport.giantswarm.io`). If it isn't set, the test will be skipped.
-
-Example kubeconfig:
-
-```yaml
-apiVersion: v1
-kind: Config
-contexts:
-- context:
-    cluster: glippy
-    user: glippy-admin
-  name: capz
-- context:
-    cluster: grizzly
-    user: grizzly-admin
-  name: capa
-- context:
-    cluster: gcapeverde
-    user: gcapeverde-admin
-  name: capv
-- context:
-    cluster: gerbil
-    user: gerbil-admin
-  name: capvcd
-clusters:
-- cluster:
-    certificate-authority-data: [REDACTED]
-    server: https://[REDACTED]:6443
-  name: glippy
-- cluster:
-    certificate-authority-data: [REDACTED]
-    server: https://[REDACTED]:6443
-  name: grizzly
-- cluster:
-    certificate-authority-data: [REDACTED]
-    server: https://[REDACTED]:6443
-  name: gcapeverde
-- cluster:
-    certificate-authority-data: [REDACTED]
-    server: https://[REDACTED]:6443
-  name: gerbil
-current-context: grizzly
-preferences: {}
-users:
-- name: glippy-admin
-  user:
-    client-certificate-data: [REDACTED]
-    client-key-data: [REDACTED]
-- name: grizzly-admin
-  user:
-    client-certificate-data: [REDACTED]
-    client-key-data: [REDACTED]
-- name: gcapeverde-admin
-  user:
-    client-certificate-data: [REDACTED]
-    client-key-data: [REDACTED]
-- name: gerbil-admin
-  user:
-    client-certificate-data: [REDACTED]
-    client-key-data: [REDACTED]
-
-```
 
 ## 🏃 Running Tests
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/giantswarm/cluster-test-suites
 
 go 1.21
 
+replace github.com/giantswarm/cluster-standup-teardown => github.com/giantswarm/cluster-standup-teardown v1.0.2-0.20240429091344-f18b62b0c51a
+
 require (
 	github.com/giantswarm/apiextensions-application v0.6.1
 	github.com/giantswarm/cluster-standup-teardown v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,9 @@ module github.com/giantswarm/cluster-test-suites
 
 go 1.21
 
-replace github.com/giantswarm/cluster-standup-teardown => github.com/giantswarm/cluster-standup-teardown v1.0.2-0.20240429091344-f18b62b0c51a
-
 require (
 	github.com/giantswarm/apiextensions-application v0.6.1
-	github.com/giantswarm/cluster-standup-teardown v1.0.1
+	github.com/giantswarm/cluster-standup-teardown v1.0.2
 	github.com/giantswarm/clustertest v0.18.0
 	github.com/gravitational/teleport/api v0.0.0-20240221014947-7cec562a5fe2
 	github.com/onsi/ginkgo/v2 v2.17.2

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkPJa+rXKBr9e0p+6nd8aw3A=
 github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/cluster-standup-teardown v1.0.2-0.20240429091344-f18b62b0c51a h1:D09ue3plnM6FH8yjoMVpm5N7GcqVI4CpPTttC6PAp0s=
-github.com/giantswarm/cluster-standup-teardown v1.0.2-0.20240429091344-f18b62b0c51a/go.mod h1:hREsAWG9OVP/wMiLdiNx1koWdC4XUsg0tPt8Zz1gf2o=
+github.com/giantswarm/cluster-standup-teardown v1.0.2 h1:+5wL7Pt/zlH1R7e1yu/ze2LgYUJTx3VmWv+9u7k8D/w=
+github.com/giantswarm/cluster-standup-teardown v1.0.2/go.mod h1:hREsAWG9OVP/wMiLdiNx1koWdC4XUsg0tPt8Zz1gf2o=
 github.com/giantswarm/clustertest v0.18.0 h1:OeiRuM3aOSzH/LzoS0FvsF8aGggc7BuRQOTB6wa+ToM=
 github.com/giantswarm/clustertest v0.18.0/go.mod h1:/lKOF0DBZs9ln8CXiq/gqIQL/rUBGXDiWHb+Q0QNlMk=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkPJa+rXKBr9e0p+6nd8aw3A=
 github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/cluster-standup-teardown v1.0.1 h1:AlVH68wydihpYTbOurVTPTxqbfgeA1kMob0wk6Fp1vs=
-github.com/giantswarm/cluster-standup-teardown v1.0.1/go.mod h1:hREsAWG9OVP/wMiLdiNx1koWdC4XUsg0tPt8Zz1gf2o=
+github.com/giantswarm/cluster-standup-teardown v1.0.2-0.20240429091344-f18b62b0c51a h1:D09ue3plnM6FH8yjoMVpm5N7GcqVI4CpPTttC6PAp0s=
+github.com/giantswarm/cluster-standup-teardown v1.0.2-0.20240429091344-f18b62b0c51a/go.mod h1:hREsAWG9OVP/wMiLdiNx1koWdC4XUsg0tPt8Zz1gf2o=
 github.com/giantswarm/clustertest v0.18.0 h1:OeiRuM3aOSzH/LzoS0FvsF8aGggc7BuRQOTB6wa+ToM=
 github.com/giantswarm/clustertest v0.18.0/go.mod h1:/lKOF0DBZs9ln8CXiq/gqIQL/rUBGXDiWHb+Q0QNlMk=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=

--- a/internal/suite/setup.go
+++ b/internal/suite/setup.go
@@ -20,7 +20,7 @@ import (
 // Setup handles the creation of the BeforeSuite and AfterSuite handlers. This covers the creations and cleanup of the test cluster.
 // `clusterReadyFns` can be provided if the cluster requires custom checks for cluster-ready status. If not provided the cluster will
 // be checked for at least a single control plane node being marked as ready.
-func Setup(isUpgrade bool, kubeContext string, clusterBuilder cb.ClusterBuilder, clusterReadyFns ...func(client *client.Client)) {
+func Setup(isUpgrade bool, clusterBuilder cb.ClusterBuilder, clusterReadyFns ...func(client *client.Client)) {
 	BeforeSuite(func() {
 		if isUpgrade && strings.TrimSpace(os.Getenv("E2E_OVERRIDE_VERSIONS")) == "" {
 			Skip("E2E_OVERRIDE_VERSIONS env var not set, skipping upgrade test")
@@ -31,7 +31,7 @@ func Setup(isUpgrade bool, kubeContext string, clusterBuilder cb.ClusterBuilder,
 
 		state.SetContext(context.Background())
 
-		framework, err := clustertest.New(kubeContext)
+		framework, err := clustertest.New(clusterBuilder.KubeContext())
 		Expect(err).NotTo(HaveOccurred())
 		state.SetFramework(framework)
 

--- a/providers/capa/private/capa_suite_test.go
+++ b/providers/capa/private/capa_suite_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/giantswarm/cluster-standup-teardown/pkg/clusterbuilder/providers/capa"
 )
 
-const KubeContext = "capa-private-proxy"
-
 func TestCAPAPrivate(t *testing.T) {
-	suite.Setup(false, KubeContext, &capa.PrivateClusterBuilder{})
+	suite.Setup(false, &capa.PrivateClusterBuilder{})
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CAPA Private Suite")

--- a/providers/capa/standard/capa_suite_test.go
+++ b/providers/capa/standard/capa_suite_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/giantswarm/cluster-standup-teardown/pkg/clusterbuilder/providers/capa"
 )
 
-const KubeContext = "capa"
-
 func TestCAPAStandard(t *testing.T) {
-	suite.Setup(false, KubeContext, &capa.ClusterBuilder{})
+	suite.Setup(false, &capa.ClusterBuilder{})
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CAPA Standard Suite")

--- a/providers/capa/upgrade/capa_suite_test.go
+++ b/providers/capa/upgrade/capa_suite_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/giantswarm/cluster-standup-teardown/pkg/clusterbuilder/providers/capa"
 )
 
-const KubeContext = "capa"
-
 func TestCAPAUpgrade(t *testing.T) {
-	suite.Setup(true, KubeContext, &capa.ClusterBuilder{})
+	suite.Setup(true, &capa.ClusterBuilder{})
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CAPA Upgrade Suite")

--- a/providers/capv/standard/capv_suite_test.go
+++ b/providers/capv/standard/capv_suite_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/suite"
 )
 
-const KubeContext = "capv"
-
 func TestCAPVStandard(t *testing.T) {
-	suite.Setup(false, KubeContext, &capv.ClusterBuilder{})
+	suite.Setup(false, &capv.ClusterBuilder{})
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CAPV Standard Suite")

--- a/providers/capv/upgrade/capv_suite_test.go
+++ b/providers/capv/upgrade/capv_suite_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/suite"
 )
 
-const KubeContext = "capv"
-
 func TestCAPVUpgrade(t *testing.T) {
-	suite.Setup(true, KubeContext, &capv.ClusterBuilder{})
+	suite.Setup(true, &capv.ClusterBuilder{})
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CAPV Upgrade Suite")

--- a/providers/capvcd/standard/capvcd_suite_test.go
+++ b/providers/capvcd/standard/capvcd_suite_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/suite"
 )
 
-const KubeContext = "capvcd"
-
 func TestCAPVCDStandard(t *testing.T) {
-	suite.Setup(false, KubeContext, &capvcd.ClusterBuilder{})
+	suite.Setup(false, &capvcd.ClusterBuilder{})
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CAPVCD Standard Suite")

--- a/providers/capvcd/upgrade/capvcd_suite_test.go
+++ b/providers/capvcd/upgrade/capvcd_suite_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/suite"
 )
 
-const KubeContext = "capvcd"
-
 func TestCAPVCDUpgrade(t *testing.T) {
-	suite.Setup(true, KubeContext, &capvcd.ClusterBuilder{})
+	suite.Setup(true, &capvcd.ClusterBuilder{})
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CAPVCD Upgrade Suite")

--- a/providers/capz/standard/capz_suite_test.go
+++ b/providers/capz/standard/capz_suite_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/suite"
 )
 
-const KubeContext = "capz"
-
 func TestCAPZStandard(t *testing.T) {
-	suite.Setup(false, KubeContext, &capz.ClusterBuilder{})
+	suite.Setup(false, &capz.ClusterBuilder{})
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CAPZ Standard Suite")

--- a/providers/capz/upgrade/capz_suite_test.go
+++ b/providers/capz/upgrade/capz_suite_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/suite"
 )
 
-const KubeContext = "capz"
-
 func TestCAPZUpgrade(t *testing.T) {
-	suite.Setup(true, KubeContext, &capz.ClusterBuilder{})
+	suite.Setup(true, &capz.ClusterBuilder{})
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CAPZ Upgrade Suite")

--- a/providers/eks/standard/eks_suite_test.go
+++ b/providers/eks/standard/eks_suite_test.go
@@ -16,10 +16,8 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/suite"
 )
 
-const KubeContext = "eks"
-
 func TestEKSStandard(t *testing.T) {
-	suite.Setup(false, KubeContext, &capa.ManagedClusterBuilder{}, func(client *client.Client) {
+	suite.Setup(false, &capa.ManagedClusterBuilder{}, func(client *client.Client) {
 		Eventually(
 			wait.AreNumNodesReady(state.GetContext(), client, 2, &cr.MatchingLabels{"node-role.kubernetes.io/worker": ""}),
 			20*time.Minute, 15*time.Second,

--- a/providers/eks/upgrade/eks_suite_test.go
+++ b/providers/eks/upgrade/eks_suite_test.go
@@ -16,10 +16,8 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/suite"
 )
 
-const KubeContext = "eks"
-
 func TestEKSUpgrade(t *testing.T) {
-	suite.Setup(true, KubeContext, &capa.ManagedClusterBuilder{}, func(client *client.Client) {
+	suite.Setup(true, &capa.ManagedClusterBuilder{}, func(client *client.Client) {
 		Eventually(
 			wait.AreNumNodesReady(state.GetContext(), client, 2, &cr.MatchingLabels{"node-role.kubernetes.io/worker": ""}),
 			20*time.Minute, 15*time.Second,


### PR DESCRIPTION
### What this PR does

#### Changed

- Updated cluster-standup-teardown to v1.0.2
- Made use of new `clusterbuilder.KubeContext()` function
- Updated readme requirements

#### Removed

- Removed KubeContext const from each test suite


Blocked by https://github.com/giantswarm/cluster-test-suites/pull/276

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
