### PR TITLE
Add private and multi-provider tests for CAPZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Private CAPZ tests.
+- CAPV on CAPZ tests.
+
 ## [1.39.1] - 2024-04-29
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.21
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.1
-	github.com/giantswarm/cluster-standup-teardown v1.0.2
-	github.com/giantswarm/clustertest v0.18.0
+	github.com/giantswarm/cluster-standup-teardown v1.0.3-0.20240507105757-5b780dbc3a31
+	github.com/giantswarm/clustertest v0.19.0
 	github.com/gravitational/teleport/api v0.0.0-20240507021047-6ce4fdd96671
 	github.com/onsi/ginkgo/v2 v2.17.2
 	github.com/onsi/gomega v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -809,10 +809,11 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkPJa+rXKBr9e0p+6nd8aw3A=
 github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/cluster-standup-teardown v1.0.2 h1:+5wL7Pt/zlH1R7e1yu/ze2LgYUJTx3VmWv+9u7k8D/w=
 github.com/giantswarm/cluster-standup-teardown v1.0.2/go.mod h1:hREsAWG9OVP/wMiLdiNx1koWdC4XUsg0tPt8Zz1gf2o=
-github.com/giantswarm/clustertest v0.18.0 h1:OeiRuM3aOSzH/LzoS0FvsF8aGggc7BuRQOTB6wa+ToM=
-github.com/giantswarm/clustertest v0.18.0/go.mod h1:/lKOF0DBZs9ln8CXiq/gqIQL/rUBGXDiWHb+Q0QNlMk=
+github.com/giantswarm/cluster-standup-teardown v1.0.3-0.20240507105757-5b780dbc3a31 h1:YXQnZccaTwikEPvGEAdfcwMORxNTLlVyiGkdiNXhqH8=
+github.com/giantswarm/cluster-standup-teardown v1.0.3-0.20240507105757-5b780dbc3a31/go.mod h1:a6PMkIxv2Pi5VrhjRdNejElDO4rRaLwV8k0AOBFLAo8=
+github.com/giantswarm/clustertest v0.19.0 h1:pogTFxyW8lgHu3aiH0WToiWK07JJGBdISMO/jpdANHM=
+github.com/giantswarm/clustertest v0.19.0/go.mod h1:/DpW/3J5Y1DhOqC9Cy7ETNVMuQcdKUlSWv8ldgOQXBU=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=
 github.com/giantswarm/k8smetadata v0.23.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.45.0 h1:4g1Fnpkf4gjxiZtFPCEIfEnEWVIpoTXj1yij4hxaOok=

--- a/providers/capv/on-capz/capv_suite_test.go
+++ b/providers/capv/on-capz/capv_suite_test.go
@@ -1,0 +1,19 @@
+package standard
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/cluster-standup-teardown/pkg/clusterbuilder/providers/capv"
+
+	"github.com/giantswarm/cluster-test-suites/internal/suite"
+)
+
+func TestCAPVStandard(t *testing.T) {
+	suite.Setup(false, &capv.ClusterBuilder{"capv-on-capz"})
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPV on CAPZ Suite")
+}

--- a/providers/capv/on-capz/capv_test.go
+++ b/providers/capv/on-capz/capv_test.go
@@ -1,0 +1,19 @@
+package standard
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/giantswarm/cluster-test-suites/internal/common"
+)
+
+var _ = Describe("Common tests", func() {
+	common.Run(&common.TestConfig{
+		// No autoscaling on-prem
+		AutoScalingSupported: false,
+		BastionSupported:     false,
+		TeleportSupported:    true,
+		// Disabled until https://github.com/giantswarm/roadmap/issues/1037
+		ExternalDnsSupported:         false,
+		ControlPlaneMetricsSupported: true,
+	})
+})

--- a/providers/capv/on-capz/test_data/cluster_values.yaml
+++ b/providers/capv/on-capz/test_data/cluster_values.yaml
@@ -1,0 +1,1 @@
+# Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown

--- a/providers/capv/on-capz/test_data/default-apps_values.yaml
+++ b/providers/capv/on-capz/test_data/default-apps_values.yaml
@@ -1,0 +1,1 @@
+# Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown

--- a/providers/capv/on-capz/test_data/helloworld_values.yaml
+++ b/providers/capv/on-capz/test_data/helloworld_values.yaml
@@ -1,0 +1,15 @@
+clusterName: {{ .ClusterName }}
+organization: {{ .Organization }}
+ingress:
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
+  hosts:
+    - host: hello-world.{{ .ClusterName }}.gaws.gigantic.io
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: hello-world-tls
+      hosts:
+        - hello-world.{{ .ClusterName }}.gaws.gigantic.io

--- a/providers/capz/private/capz_suite_test.go
+++ b/providers/capz/private/capz_suite_test.go
@@ -1,0 +1,19 @@
+package standard
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/cluster-standup-teardown/pkg/clusterbuilder/providers/capz"
+
+	"github.com/giantswarm/cluster-test-suites/internal/suite"
+)
+
+func TestCAPZStandard(t *testing.T) {
+	suite.Setup(false, &capz.ClusterBuilder{CustomKubeContext: "capz-private"})
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPZ Private Suite")
+}

--- a/providers/capz/private/capz_test.go
+++ b/providers/capz/private/capz_test.go
@@ -1,0 +1,19 @@
+package standard
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/giantswarm/cluster-test-suites/internal/common"
+)
+
+var _ = Describe("Common tests", func() {
+	common.Run(&common.TestConfig{
+		// Disabled until https://github.com/giantswarm/roadmap/issues/2693
+		AutoScalingSupported: false,
+		BastionSupported:     false,
+		TeleportSupported:    true,
+		// Disabled until wildcard ingress support is added
+		ExternalDnsSupported:         false,
+		ControlPlaneMetricsSupported: true,
+	})
+})

--- a/providers/capz/private/test_data/cluster_values.yaml
+++ b/providers/capz/private/test_data/cluster_values.yaml
@@ -1,0 +1,5 @@
+# Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
+global:
+  connectivity:
+    network:
+      mode: private

--- a/providers/capz/private/test_data/default-apps_values.yaml
+++ b/providers/capz/private/test_data/default-apps_values.yaml
@@ -1,0 +1,1 @@
+# Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown

--- a/providers/capz/private/test_data/helloworld_values.yaml
+++ b/providers/capz/private/test_data/helloworld_values.yaml
@@ -1,0 +1,15 @@
+clusterName: {{ .ClusterName }}
+organization: {{ .Organization }}
+ingress:
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
+  hosts:
+    - host: {{ index .ExtraValues "IngressUrl" }}
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: hello-world-tls
+      hosts:
+        - {{ index .ExtraValues "IngressUrl" }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2961

### What this PR does

Introduces two test lanes: 
- Private CAPZ WCs
- CAPV WCs on CAPZ MCs.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/run cluster-test-suites
