### PR TITLE
[WIP] Add private capz tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CAPV on CAPZ tests.
+- Private CAPZ tests.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Added
+
+- CAPV on CAPZ tests.
+
 ### Changed
 
 - Make error messages actionable for Prometheus metrics query test failures

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.1
-	github.com/giantswarm/cluster-standup-teardown v1.0.2
+	github.com/giantswarm/cluster-standup-teardown v1.0.3
 	github.com/giantswarm/clustertest v0.19.0
 	github.com/gravitational/teleport/api v0.0.0-20240507021047-6ce4fdd96671
 	github.com/onsi/ginkgo/v2 v2.17.2

--- a/go.sum
+++ b/go.sum
@@ -809,8 +809,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkPJa+rXKBr9e0p+6nd8aw3A=
 github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/cluster-standup-teardown v1.0.2 h1:+5wL7Pt/zlH1R7e1yu/ze2LgYUJTx3VmWv+9u7k8D/w=
-github.com/giantswarm/cluster-standup-teardown v1.0.2/go.mod h1:hREsAWG9OVP/wMiLdiNx1koWdC4XUsg0tPt8Zz1gf2o=
+github.com/giantswarm/cluster-standup-teardown v1.0.3 h1:yy30DaT1Py5h4YsL7tZQ0tildFK4a4lHaMVEaokSuFY=
+github.com/giantswarm/cluster-standup-teardown v1.0.3/go.mod h1:/uovQzJa8oT8DU0Vfi6iPozehj8cfzLIAronnHvU9Bw=
 github.com/giantswarm/clustertest v0.19.0 h1:pogTFxyW8lgHu3aiH0WToiWK07JJGBdISMO/jpdANHM=
 github.com/giantswarm/clustertest v0.19.0/go.mod h1:/DpW/3J5Y1DhOqC9Cy7ETNVMuQcdKUlSWv8ldgOQXBU=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=

--- a/providers/capv/on-capz/capv_suite_test.go
+++ b/providers/capv/on-capz/capv_suite_test.go
@@ -1,0 +1,19 @@
+package standard
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/cluster-standup-teardown/pkg/clusterbuilder/providers/capv"
+
+	"github.com/giantswarm/cluster-test-suites/internal/suite"
+)
+
+func TestCAPVStandard(t *testing.T) {
+	suite.Setup(false, &capv.ClusterBuilder{"capv-on-capz"})
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPV on CAPZ Suite")
+}

--- a/providers/capv/on-capz/capv_test.go
+++ b/providers/capv/on-capz/capv_test.go
@@ -1,0 +1,19 @@
+package standard
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/giantswarm/cluster-test-suites/internal/common"
+)
+
+var _ = Describe("Common tests", func() {
+	common.Run(&common.TestConfig{
+		// No autoscaling on-prem
+		AutoScalingSupported: false,
+		BastionSupported:     false,
+		TeleportSupported:    true,
+		// Disabled until https://github.com/giantswarm/roadmap/issues/1037
+		ExternalDnsSupported:         false,
+		ControlPlaneMetricsSupported: true,
+	})
+})

--- a/providers/capv/on-capz/test_data/cluster_values.yaml
+++ b/providers/capv/on-capz/test_data/cluster_values.yaml
@@ -1,0 +1,2 @@
+# Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
+baseDomain: azuretest.gigantic.io

--- a/providers/capv/on-capz/test_data/default-apps_values.yaml
+++ b/providers/capv/on-capz/test_data/default-apps_values.yaml
@@ -1,0 +1,1 @@
+# Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown

--- a/providers/capv/on-capz/test_data/helloworld_values.yaml
+++ b/providers/capv/on-capz/test_data/helloworld_values.yaml
@@ -1,0 +1,15 @@
+clusterName: {{ .ClusterName }}
+organization: {{ .Organization }}
+ingress:
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
+  hosts:
+    - host: hello-world.{{ .ClusterName }}.gaws.gigantic.io
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: hello-world-tls
+      hosts:
+        - hello-world.{{ .ClusterName }}.gaws.gigantic.io

--- a/providers/capz/private/capz_suite_test.go
+++ b/providers/capz/private/capz_suite_test.go
@@ -1,0 +1,19 @@
+package standard
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/cluster-standup-teardown/pkg/clusterbuilder/providers/capz"
+
+	"github.com/giantswarm/cluster-test-suites/internal/suite"
+)
+
+func TestCAPZStandard(t *testing.T) {
+	suite.Setup(false, &capz.ClusterBuilder{CustomKubeContext: "capz-private"})
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPZ Private Suite")
+}

--- a/providers/capz/private/capz_test.go
+++ b/providers/capz/private/capz_test.go
@@ -1,0 +1,19 @@
+package standard
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/giantswarm/cluster-test-suites/internal/common"
+)
+
+var _ = Describe("Common tests", func() {
+	common.Run(&common.TestConfig{
+		// Disabled until https://github.com/giantswarm/roadmap/issues/2693
+		AutoScalingSupported: false,
+		BastionSupported:     false,
+		TeleportSupported:    true,
+		// Disabled until wildcard ingress support is added
+		ExternalDnsSupported:         false,
+		ControlPlaneMetricsSupported: true,
+	})
+})

--- a/providers/capz/private/test_data/cluster_values.yaml
+++ b/providers/capz/private/test_data/cluster_values.yaml
@@ -1,0 +1,5 @@
+# Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
+global:
+  connectivity:
+    network:
+      mode: private

--- a/providers/capz/private/test_data/default-apps_values.yaml
+++ b/providers/capz/private/test_data/default-apps_values.yaml
@@ -1,0 +1,1 @@
+# Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown

--- a/providers/capz/private/test_data/helloworld_values.yaml
+++ b/providers/capz/private/test_data/helloworld_values.yaml
@@ -1,0 +1,15 @@
+clusterName: {{ .ClusterName }}
+organization: {{ .Organization }}
+ingress:
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
+  hosts:
+    - host: {{ index .ExtraValues "IngressUrl" }}
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: hello-world-tls
+      hosts:
+        - {{ index .ExtraValues "IngressUrl" }}


### PR DESCRIPTION
On top of https://github.com/giantswarm/cluster-test-suites/pull/285

### What this PR does

Adds private CAPZ tests. 

***NOTE:*** This PR is blocked now since the private WCs are fully closed. We need to extend the test suite functionality so that we can access WCs via teleport.

Blocked by https://github.com/giantswarm/giantswarm/issues/30767

### Checklist

- [ ] Update changelog in CHANGELOG.md.
