### PR TITLE
Add test for CAPA cluster in Cilium ENI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Running a single test suite with teleport test enabled (e.g. the `capa` `standar
 ```sh
 kubectl get secrets teleport-identity-output -n tekton-pipelines --template='{{.data.identity}}' | base64 -D > teleport-identity-file.pem
 
-E2E_KUBECONFIG=/path/to/kubeconfig.yaml TELEPORT_IDENITTY_FILE=/path/to/teleport-identity-file.pem -v -r ./providers/capa/standard
+E2E_KUBECONFIG=/path/to/kubeconfig.yaml TELEPORT_IDENTITY_FILE=/path/to/teleport-identity-file.pem -v -r ./providers/capa/standard
 ```
 
 Running with Docker:

--- a/providers/capa/cilium-eni-mode/capa_suite_test.go
+++ b/providers/capa/cilium-eni-mode/capa_suite_test.go
@@ -1,0 +1,19 @@
+package cilium_eni_mode
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/cluster-test-suites/internal/suite"
+
+	"github.com/giantswarm/cluster-standup-teardown/pkg/clusterbuilder/providers/capa"
+)
+
+func TestCAPACiliumEniMode(t *testing.T) {
+	suite.Setup(false, &capa.ClusterBuilder{})
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPA 'Cilium ENI mode' Suite")
+}

--- a/providers/capa/cilium-eni-mode/capa_test.go
+++ b/providers/capa/cilium-eni-mode/capa_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
 
-var _ = Describe("Cilium ENI mode tests", Ordered, func() {
+var _ = Describe("Cilium ENI mode tests", func() {
 	common.Run(&common.TestConfig{
 		AutoScalingSupported:         true,
 		BastionSupported:             false,

--- a/providers/capa/cilium-eni-mode/capa_test.go
+++ b/providers/capa/cilium-eni-mode/capa_test.go
@@ -1,12 +1,19 @@
 package cilium_eni_mode
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/giantswarm/cluster-test-suites/internal/common"
+	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
 
-var _ = Describe("Common tests", func() {
+var _ = Describe("Cilium ENI mode tests", Ordered, func() {
 	common.Run(&common.TestConfig{
 		AutoScalingSupported:         true,
 		BastionSupported:             false,
@@ -14,4 +21,33 @@ var _ = Describe("Common tests", func() {
 		ExternalDnsSupported:         true,
 		ControlPlaneMetricsSupported: true,
 	})
+
+	runSecondaryPodIPs()
 })
+
+func runSecondaryPodIPs() {
+	It("assigns IP addresses from secondary VPC CIDR to pods", func() {
+		wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+		if err != nil {
+			Fail(err.Error())
+		}
+
+		podList := &corev1.PodList{}
+		err = wcClient.List(context.Background(), podList)
+		if err != nil {
+			Fail(err.Error())
+		}
+
+		numPodsWithSecondaryCIDRPodIP := 0
+		foundPodIPs := []string{}
+		for _, pod := range podList.Items {
+			if strings.HasPrefix(pod.Status.PodIP, "10.1.") {
+				numPodsWithSecondaryCIDRPodIP++
+			}
+
+			foundPodIPs = append(foundPodIPs, pod.Status.PodIP)
+		}
+
+		Expect(numPodsWithSecondaryCIDRPodIP).Should(BeNumerically(">=", 5), fmt.Sprintf("Many pods (except those on host network, for example) should have an IP assigned from the secondary CIDR block 10.1.0.0/16. Found these pod IPs: %s", strings.Join(foundPodIPs, ", ")))
+	})
+}

--- a/providers/capa/cilium-eni-mode/capa_test.go
+++ b/providers/capa/cilium-eni-mode/capa_test.go
@@ -1,0 +1,17 @@
+package cilium_eni_mode
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/giantswarm/cluster-test-suites/internal/common"
+)
+
+var _ = Describe("Common tests", func() {
+	common.Run(&common.TestConfig{
+		AutoScalingSupported:         true,
+		BastionSupported:             false,
+		TeleportSupported:            true,
+		ExternalDnsSupported:         true,
+		ControlPlaneMetricsSupported: true,
+	})
+})

--- a/providers/capa/cilium-eni-mode/test_data/cluster_values.yaml
+++ b/providers/capa/cilium-eni-mode/test_data/cluster_values.yaml
@@ -1,0 +1,10 @@
+# Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
+global:
+  connectivity:
+    # These two settings enable Cilium ENI mode
+    network:
+      pods:
+        cidrBlocks:
+          - 10.1.0.0/16
+    cilium:
+      ipamMode: eni

--- a/providers/capa/cilium-eni-mode/test_data/default-apps_values.yaml
+++ b/providers/capa/cilium-eni-mode/test_data/default-apps_values.yaml
@@ -1,0 +1,1 @@
+# Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown

--- a/providers/capa/cilium-eni-mode/test_data/helloworld_values.yaml
+++ b/providers/capa/cilium-eni-mode/test_data/helloworld_values.yaml
@@ -1,0 +1,15 @@
+clusterName: {{ .ClusterName }}
+organization: {{ .Organization }}
+ingress:
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
+  hosts:
+    - host: {{ index .ExtraValues "IngressUrl" }}
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: hello-world-tls
+      hosts:
+        - {{ index .ExtraValues "IngressUrl" }}

--- a/providers/capa/cilium-eni-mode/test_data/scale_helloworld_values.yaml
+++ b/providers/capa/cilium-eni-mode/test_data/scale_helloworld_values.yaml
@@ -1,0 +1,15 @@
+clusterName: {{ .ClusterName }}
+organization: {{ .Organization }}
+autoscaling:
+  enabled: false
+replicaCount: {{ index .ExtraValues "ReplicaCount" }}
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/instance
+          operator: In
+          values:
+          - scale-hello-world
+      topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
### What this PR does

Towards https://github.com/giantswarm/roadmap/issues/2563

To ensure we're testing the right thing, I've added a basic "is this really ENI mode" check (pod IPs).

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
