### PR TITLE
Disable capa-private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Make error messages actionable for Prometheus metrics query test failures
+- Disabled `capa-private` until we have fixed the userdata issue with MachinePools on `goat`
 
 ## [1.39.1] - 2024-04-29
 

--- a/providers/capa/private/capa_test.go
+++ b/providers/capa/private/capa_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = Describe("Common tests", func() {
+var _ = XDescribe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		AutoScalingSupported:         true,
 		BastionSupported:             false,


### PR DESCRIPTION
### What this PR does

Disables the `capa-private` E2E tests until we have been able to fix `goat`

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
