### PR TITLE
Get baseDomain from cluster values instead of default-apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Get base domain from Cluster values instead of default-apps values
+
 ## [1.40.0] - 2024-05-10
 
 ### Changed

--- a/internal/common/dns.go
+++ b/internal/common/dns.go
@@ -19,7 +19,7 @@ func runDNS(bastionSuppoted bool) {
 	Context("dns", func() {
 		var (
 			resolver *net.Resolver
-			values   *application.DefaultAppsValues
+			values   *application.ClusterValues
 		)
 		getARecords := func(domain string) ([]net.IP, error) {
 			records, err := resolver.LookupIP(context.Background(), "ip", domain)
@@ -33,9 +33,8 @@ func runDNS(bastionSuppoted bool) {
 		}
 
 		BeforeEach(func() {
-			values = &application.DefaultAppsValues{}
-			defaultAppsName := fmt.Sprintf("%s-default-apps", state.GetCluster().Name)
-			err := state.GetFramework().MC().GetHelmValues(defaultAppsName, state.GetCluster().GetNamespace(), values)
+			values = &application.ClusterValues{}
+			err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
 			Expect(err).NotTo(HaveOccurred())
 
 			resolver = &net.Resolver{

--- a/internal/common/hello.go
+++ b/internal/common/hello.go
@@ -245,7 +245,7 @@ func runHelloWorld(externalDnsSupported bool) {
 }
 
 func getWorkloadClusterDnsZone() string {
-	values := &application.DefaultAppsValues{}
+	values := &application.ClusterValues{}
 	err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
### What this PR does

Uses the values from the cluster chart to get the `baseDomain` property instead of from the default-apps values. This should allow up to then get rid of the `DefaultAppsValues` type from `clustertest`.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
