### PR TITLE
Add support for unified cluster-aws app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Get base domain from Cluster values instead of default-apps values
 
+### Added
+
+- Add support for unified cluster-aws app. With cluster-aws v0.76.0 and newer, default apps are deployed with cluster-aws and default-apps-aws app is not deployed anymore.
+
 ## [1.40.0] - 2024-05-10
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.21
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.1
-	github.com/giantswarm/cluster-standup-teardown v1.1.0
-	github.com/giantswarm/clustertest v0.20.1
+	github.com/giantswarm/cluster-standup-teardown v1.2.0
+	github.com/giantswarm/clustertest v0.21.0
 	github.com/gravitational/teleport/api v0.0.0-20240513131144-33e80cd8f2ff
 	github.com/onsi/ginkgo/v2 v2.17.3
 	github.com/onsi/gomega v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -809,10 +809,10 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkPJa+rXKBr9e0p+6nd8aw3A=
 github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/cluster-standup-teardown v1.1.0 h1:Lo08V5XHp//i3SpCDTWcZPrXe0ric5vPUd/cAP/UhJc=
-github.com/giantswarm/cluster-standup-teardown v1.1.0/go.mod h1:TV5r27vdPGRUAwH5KOijcOiIL/lWDSg3ayRHbhXVDUc=
-github.com/giantswarm/clustertest v0.20.1 h1:0H/S1Hb+GYj027Awoq20S/Mq9axN9JQVui/OxsyttYs=
-github.com/giantswarm/clustertest v0.20.1/go.mod h1:HT7dW/kX1dzeHw+ina8vwv6P0X23u7A4p3IS+YcV6LU=
+github.com/giantswarm/cluster-standup-teardown v1.2.0 h1:HnPjAnW8pFOCmTCSs1/6e0Z7Lb1sEYGa0JC3yEUFsJ4=
+github.com/giantswarm/cluster-standup-teardown v1.2.0/go.mod h1:7l6v6Z5CFiCMUk8n/8rQHzWeqFRCMZquG8VtYK1TmJ8=
+github.com/giantswarm/clustertest v0.21.0 h1:r/EkXaQ4xmk3k66fEKrWp6ztib3d+Q8QtU+8MFMkJ6g=
+github.com/giantswarm/clustertest v0.21.0/go.mod h1:qBTNLdfn/kYpAKl1oSuOZRolSG805umQgZAusERPJck=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=
 github.com/giantswarm/k8smetadata v0.23.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.45.0 h1:4g1Fnpkf4gjxiZtFPCEIfEnEWVIpoTXj1yij4hxaOok=

--- a/internal/common/apps.go
+++ b/internal/common/apps.go
@@ -19,13 +19,13 @@ import (
 func runApps() {
 	Context("default apps", func() {
 		It("all default apps are deployed without issues", func() {
-			skipDefaultApps, err := state.GetCluster().UsesUnifiedClusterApp()
+			skipDefaultAppsApp, err := state.GetCluster().UsesUnifiedClusterApp()
 			Expect(err).NotTo(HaveOccurred())
 
 			// We need to wait for default-apps to be deployed before we can check all apps.
 			defaultAppsAppName := fmt.Sprintf("%s-%s", state.GetCluster().Name, "default-apps")
 
-			if skipDefaultApps {
+			if skipDefaultAppsApp {
 				logger.Log("Checking default apps deployed from the unified %s app (with default apps), so skipping check of %s App resource as it does not exist.", state.GetCluster().ClusterApp.AppName, state.GetCluster().DefaultAppsApp.AppName)
 			} else {
 				Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), defaultAppsAppName, state.GetCluster().Organization.GetNamespace())).
@@ -35,7 +35,7 @@ func runApps() {
 			}
 
 			var defaultAppsSelectorLabels ctrl.MatchingLabels
-			if skipDefaultApps {
+			if skipDefaultAppsApp {
 				defaultAppsSelectorLabels = ctrl.MatchingLabels{
 					"giantswarm.io/cluster":        state.GetCluster().Name,
 					"app.kubernetes.io/managed-by": "Helm",

--- a/internal/common/apps.go
+++ b/internal/common/apps.go
@@ -5,11 +5,13 @@ import (
 	"time"
 
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
-	"github.com/giantswarm/clustertest/pkg/wait"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/clustertest/pkg/logger"
+	"github.com/giantswarm/clustertest/pkg/wait"
 
 	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
@@ -17,18 +19,36 @@ import (
 func runApps() {
 	Context("default apps", func() {
 		It("all default apps are deployed without issues", func() {
+			skipDefaultApps, err := state.GetCluster().UsesUnifiedClusterApp()
+			Expect(err).NotTo(HaveOccurred())
 
 			// We need to wait for default-apps to be deployed before we can check all apps.
 			defaultAppsAppName := fmt.Sprintf("%s-%s", state.GetCluster().Name, "default-apps")
 
-			Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), defaultAppsAppName, state.GetCluster().Organization.GetNamespace())).
-				WithTimeout(30 * time.Second).
-				WithPolling(50 * time.Millisecond).
-				Should(BeTrue())
+			if skipDefaultApps {
+				logger.Log("Checking default apps deployed from the unified %s app (with default apps), so skipping check of %s App resource as it does not exist.", state.GetCluster().ClusterApp.AppName, state.GetCluster().DefaultAppsApp.AppName)
+			} else {
+				Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), defaultAppsAppName, state.GetCluster().Organization.GetNamespace())).
+					WithTimeout(30 * time.Second).
+					WithPolling(50 * time.Millisecond).
+					Should(BeTrue())
+			}
+
+			var defaultAppsSelectorLabels ctrl.MatchingLabels
+			if skipDefaultApps {
+				defaultAppsSelectorLabels = ctrl.MatchingLabels{
+					"giantswarm.io/cluster":        state.GetCluster().Name,
+					"app.kubernetes.io/managed-by": "Helm",
+				}
+			} else {
+				defaultAppsSelectorLabels = ctrl.MatchingLabels{
+					"giantswarm.io/managed-by": defaultAppsAppName,
+				}
+			}
 
 			// Wait for all default-apps apps to be deployed
 			appList := &v1alpha1.AppList{}
-			err := state.GetFramework().MC().List(state.GetContext(), appList, ctrl.InNamespace(state.GetCluster().Organization.GetNamespace()), ctrl.MatchingLabels{"giantswarm.io/managed-by": defaultAppsAppName})
+			err = state.GetFramework().MC().List(state.GetContext(), appList, ctrl.InNamespace(state.GetCluster().Organization.GetNamespace()), defaultAppsSelectorLabels)
 			Expect(err).NotTo(HaveOccurred())
 
 			appNamespacedNames := []types.NamespacedName{}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -82,10 +82,15 @@ func Run(cfg *TestConfig) {
 				10*time.Minute, 5*time.Second,
 			).Should(BeTrue())
 
-			Eventually(
-				wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), defaultAppsApp.Name, defaultAppsApp.Namespace),
-				10*time.Minute, 5*time.Second,
-			).Should(BeTrue())
+			skipDefaultAppsApp, err := cluster.UsesUnifiedClusterApp()
+			Expect(err).NotTo(HaveOccurred())
+
+			if !skipDefaultAppsApp {
+				Eventually(
+					wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), defaultAppsApp.Name, defaultAppsApp.Namespace),
+					10*time.Minute, 5*time.Second,
+				).Should(BeTrue())
+			}
 
 			Eventually(
 				wait.IsAppVersion(state.GetContext(), state.GetFramework().MC(), clusterApp.Name, clusterApp.Namespace, clusterApp.Spec.Version),


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3119

I ran tests locally (with this cluster-test-suites branch and [this cluster-aws PR](https://github.com/giantswarm/cluster-aws/pull/581)) and only this failed, but this same error happened also when I ran tests locally with cluster-test-suites main branch and latest release of with cluster-aws:

```
Common tests metrics [It] ensure key metrics are available on prometheus
/Users/nikola/src/giantswarm/cluster-test-suites/internal/common/metrics.go:88

  [FAILED] Timed out after 600.002s.
  Expected success, but got an error:
      <*errors.errorString | 0x14000dab230>:
      can't exec command in pod t-llcppvi2gcp16fa900-metrics-test: failed to exec command in pod - command terminated with exit code 1 (stderr: "Connecting to mimir-gateway.mimir:80 (172.31.223.66:80)\nwget: server returned error: HTTP/1.1 401 Unauthorized\n")
      {
          s: "can't exec command in pod t-llcppvi2gcp16fa900-metrics-test: failed to exec command in pod - command terminated with exit code 1 (stderr: \"Connecting to mimir-gateway.mimir:80 (172.31.223.66:80)\\nwget: server returned error: HTTP/1.1 401 Unauthorized\\n\")",
      }
  In [It] at: /Users/nikola/src/giantswarm/cluster-test-suites/internal/common/metrics.go:93
```

### What this PR does

With cluster-aws v0.76.0 and newer, default apps are deployed with cluster-aws and default-apps-aws app is not deployed anymore.

Note: The latest cluster-aws release is v0.75.0 and the [default apps addition](https://github.com/giantswarm/cluster-aws/pull/581) is not yet merged (but it has been tested and it's ready to be merged). This PR assumes that the [default apps addition](https://github.com/giantswarm/cluster-aws/pull/581) will be merged and that v0.76.0 will be released.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
