### PR TITLE
[WiP] Test with prom volume label set to small

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.1
-	github.com/giantswarm/cluster-standup-teardown v1.1.0
+	github.com/giantswarm/cluster-standup-teardown v1.1.1-0.20240514070842-f13c5f6ab9b1
 	github.com/giantswarm/clustertest v0.20.1
 	github.com/gravitational/teleport/api v0.0.0-20240513131144-33e80cd8f2ff
 	github.com/onsi/ginkgo/v2 v2.17.3

--- a/go.sum
+++ b/go.sum
@@ -811,6 +811,8 @@ github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkP
 github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/cluster-standup-teardown v1.1.0 h1:Lo08V5XHp//i3SpCDTWcZPrXe0ric5vPUd/cAP/UhJc=
 github.com/giantswarm/cluster-standup-teardown v1.1.0/go.mod h1:TV5r27vdPGRUAwH5KOijcOiIL/lWDSg3ayRHbhXVDUc=
+github.com/giantswarm/cluster-standup-teardown v1.1.1-0.20240514070842-f13c5f6ab9b1 h1:cAGCave9k+apOGMo3gqKahPru/A6Jbcwx2XHV28leRI=
+github.com/giantswarm/cluster-standup-teardown v1.1.1-0.20240514070842-f13c5f6ab9b1/go.mod h1:xczd5WzcSlmZX78U31cjxUi+FCIfEI7wLLwC2MQZdx4=
 github.com/giantswarm/clustertest v0.20.1 h1:0H/S1Hb+GYj027Awoq20S/Mq9axN9JQVui/OxsyttYs=
 github.com/giantswarm/clustertest v0.20.1/go.mod h1:HT7dW/kX1dzeHw+ina8vwv6P0X23u7A4p3IS+YcV6LU=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=


### PR DESCRIPTION
### What this PR does

Tests the changes in https://github.com/giantswarm/cluster-standup-teardown/pull/22 to ensure that reducing the prom volume size doesn't impact the tests.

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
