### PR TITLE
Add specific renovate config for teleport dep

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,5 +6,15 @@
   "prBodyNotes": [
     "Trigger E2E tests:",
     "/run cluster-test-suites"
-  ]
+  ],
+  "packageRules": [
+    {
+      // Prevent Teleport updating every time the repo has a new commit, instead update weekly
+      "matchPackagePatterns": ["github.com/gravitational/teleport/.*"],
+      "groupName": "Teleport Modules",
+      "matchManagers": ["gomod"],
+      "additionalReviewers": ["team:team-bigmac"],
+      "schedule": ["before 5am on Monday"],
+    },
+  ],
 }


### PR DESCRIPTION
### What this PR does

Sets a specific Renovate config for the teleport dependencies to prevent the constant PRs every time the upstream repo has a new commit. Currently changed it to weekly but might eventually drop it to monthly if still too annoying.

@giantswarm/team-bigmac I've also added y'all as a reviewer specifically for this dependency so y'all are aware of the updates and can block any you know are going to cause problems.

FYI - I attempted to find a way to have the dependencies follow the releases on the GitHub repo but I couldn't find any way to manage that. I saw there was a [discussion upstream](https://github.com/renovatebot/renovate/discussions/27996) with someone asking the same with no replies. 😞 
