### PR TITLE
increase kubeadmcontrolplane rollout timeout from 20min to 30min

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Wait and test for `security-bundle` apps to be deployed.
 
+### Changed
+
+- Increase `kubeadmControlPlane` rollout timeout from 20min to 30min.
+
 ## [1.42.0] - 2024-05-14
 
 ### Added

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -141,7 +141,7 @@ func Run(cfg *TestConfig) {
 			mcClient := state.GetFramework().MC()
 			Eventually(
 				wait.IsKubeadmControlPlaneConditionSet(state.GetContext(), mcClient, cluster.Name, cluster.GetNamespace(), kubeadm.MachinesSpecUpToDateCondition, corev1.ConditionTrue, ""),
-				20*time.Minute,
+				30*time.Minute,
 				30*time.Second,
 			).Should(BeTrue())
 		})


### PR DESCRIPTION
### What this PR does

CAPVCD is slower than other providers and always times out when upgrading the CP nodes.
I tested manually and babysat a pipelinerun, it all works fine, it's just slow.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
