### PR TITLE
Increase check time for upgrade status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Wait and test for `security-bundle` apps to be deployed.
 
+### Changed
+
+- Increase node roll check time to 180 seconds from 25 seconds in the upgrade test.
+
 ## [1.42.0] - 2024-05-14
 
 ### Added

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -106,8 +106,8 @@ func Run(cfg *TestConfig) {
 		It("successfully finishes control plane nodes rolling update if it is needed", func() {
 			// Check MachinesSpecUpToDate condition on KubeadmControlPlane. Repeat the check 5 times, with some waiting time,
 			// so Cluster API controllers have time to react to upgrade (it is usually instantaneous).
-			numberOfChecks := 5
-			waitBetweenChecks := 5 * time.Second
+			numberOfChecks := 18
+			waitBetweenChecks := 10 * time.Second
 			controlPlaneRollingUpdateStarted := false
 
 			for i := 0; i < numberOfChecks; i++ {


### PR DESCRIPTION
### What this PR does

This PR increases the node roll check timeout to 180 seconds instead of 25 seconds when doing the upgrade test. 
This is the time it waits for the control plane node roll status to update. 

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
