### PR TITLE
Reduce the timeout for default-apps tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Increase node roll check time to 180 seconds from 25 seconds in the upgrade test.
+- Reduce the timeout for default apps checks
 
 ## [1.42.0] - 2024-05-14
 

--- a/internal/common/apps.go
+++ b/internal/common/apps.go
@@ -84,7 +84,7 @@ func runApps() {
 			}
 
 			Eventually(wait.IsAllAppDeployed(state.GetContext(), state.GetFramework().MC(), appNamespacedNames)).
-				WithTimeout(25 * time.Minute).
+				WithTimeout(8 * time.Minute).
 				WithPolling(10 * time.Second).
 				Should(BeTrue())
 		})
@@ -111,7 +111,7 @@ func runApps() {
 			}
 
 			Eventually(wait.IsAllAppDeployed(state.GetContext(), state.GetFramework().MC(), appNamespacedNames)).
-				WithTimeout(15 * time.Minute).
+				WithTimeout(10 * time.Minute).
 				WithPolling(10 * time.Second).
 				Should(BeTrue())
 		})


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/giantswarm/giantswarm/issues/30777

Reduces the timeout for some of the default-apps tests to more realistic values to save waiting for too long when failures occur.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
