### PR TITLE
Fix default-apps-aws check in upgrade test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Increase node roll check time to 180 seconds from 25 seconds in the upgrade test.
 
+### Fixed
+
+- Skip checking default-apps-aws version when unified cluster-aws app is deployed.
+
 ## [1.42.0] - 2024-05-14
 
 ### Added

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -77,15 +77,15 @@ func Run(cfg *TestConfig) {
 
 			clusterApp, _, defaultAppsApp, _, _ := cluster.Build()
 
-			Eventually(
-				wait.IsAppVersion(state.GetContext(), state.GetFramework().MC(), defaultAppsApp.Name, defaultAppsApp.Namespace, defaultAppsApp.Spec.Version),
-				10*time.Minute, 5*time.Second,
-			).Should(BeTrue())
-
 			skipDefaultAppsApp, err := cluster.UsesUnifiedClusterApp()
 			Expect(err).NotTo(HaveOccurred())
 
 			if !skipDefaultAppsApp {
+				Eventually(
+					wait.IsAppVersion(state.GetContext(), state.GetFramework().MC(), defaultAppsApp.Name, defaultAppsApp.Namespace, defaultAppsApp.Spec.Version),
+					10*time.Minute, 5*time.Second,
+				).Should(BeTrue())
+
 				Eventually(
 					wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), defaultAppsApp.Name, defaultAppsApp.Namespace),
 					10*time.Minute, 5*time.Second,


### PR DESCRIPTION
### What this PR does

Skip checking default-apps-aws version when unified cluster-aws app is deployed.

I missed this check in the original PR 🙈

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
