### PR TITLE
update cluster-standup-teardown to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `cluster-standup-teardown` to v1.3.0
+
 ## [1.44.0] - 2024-05-16
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.1
-	github.com/giantswarm/cluster-standup-teardown v1.2.0
+	github.com/giantswarm/cluster-standup-teardown v1.3.0
 	github.com/giantswarm/clustertest v0.21.0
 	github.com/gravitational/teleport/api v0.0.0-20240513131144-33e80cd8f2ff
 	github.com/onsi/ginkgo/v2 v2.17.3

--- a/go.sum
+++ b/go.sum
@@ -809,8 +809,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkPJa+rXKBr9e0p+6nd8aw3A=
 github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/cluster-standup-teardown v1.2.0 h1:HnPjAnW8pFOCmTCSs1/6e0Z7Lb1sEYGa0JC3yEUFsJ4=
-github.com/giantswarm/cluster-standup-teardown v1.2.0/go.mod h1:7l6v6Z5CFiCMUk8n/8rQHzWeqFRCMZquG8VtYK1TmJ8=
+github.com/giantswarm/cluster-standup-teardown v1.3.0 h1:DMuSJJtPbVm7hMZGK/OpaOzPeYXCGGPQG0NkfogXcSI=
+github.com/giantswarm/cluster-standup-teardown v1.3.0/go.mod h1:7l6v6Z5CFiCMUk8n/8rQHzWeqFRCMZquG8VtYK1TmJ8=
 github.com/giantswarm/clustertest v0.21.0 h1:r/EkXaQ4xmk3k66fEKrWp6ztib3d+Q8QtU+8MFMkJ6g=
 github.com/giantswarm/clustertest v0.21.0/go.mod h1:qBTNLdfn/kYpAKl1oSuOZRolSG805umQgZAusERPJck=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=

--- a/providers/capv/on-capz/test_data/cluster_values.yaml
+++ b/providers/capv/on-capz/test_data/cluster_values.yaml
@@ -1,2 +1,4 @@
 # Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
-baseDomain: azuretest.gigantic.io
+global:
+  connectivity:
+    baseDomain: azuretest.gigantic.io


### PR DESCRIPTION
### What this PR does

Updates cluster-standup-teardown to v1.3.0

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
