### PR TITLE
Add timeout flag to readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ If you need the current teleport identity file its best to pull it from the `tel
 Running the all test suites:
 
 ```sh
-E2E_KUBECONFIG=/path/to/kubeconfig.yaml ginkgo -v -r .
+E2E_KUBECONFIG=/path/to/kubeconfig.yaml ginkgo --timeout 4h -v -r .
 ```
 
 Running a single provider (e.g. `capa`):
 
 ```sh
-E2E_KUBECONFIG=/path/to/kubeconfig.yaml ginkgo -v -r ./providers/capa
+E2E_KUBECONFIG=/path/to/kubeconfig.yaml ginkgo --timeout 4h -v -r ./providers/capa
 ```
 
 Running a single test suite (e.g. the `capa` `standard` test suite)
 
 ```sh
-E2E_KUBECONFIG=/path/to/kubeconfig.yaml ginkgo -v -r ./providers/capa/standard
+E2E_KUBECONFIG=/path/to/kubeconfig.yaml ginkgo --timeout 4h -v -r ./providers/capa/standard
 ```
 
 Running a single test suite with teleport test enabled (e.g. the `capa` `standard` test suite):


### PR DESCRIPTION
### What this PR does

Add the `--timeout` flag to the example commands as otherwise it is possible for the tests to fail if they take longer than 1 hour (e.g. the CAPA China test suite)

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

Skipping tests as just a readme update.
