### PR TITLE
Switch to using new `ApplyBuiltCluster` in upgrade tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `clustertest` and `cluster-standup-teardown` to latest releases
+- Switch to using new `ApplyBuiltCluster` in upgrade tests to avoid building the cluster twice
+
 ## [1.45.0] - 2024-06-10
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ toolchain go1.22.4
 
 require (
 	github.com/giantswarm/apiextensions-application v0.6.1
-	github.com/giantswarm/cluster-standup-teardown v1.6.0
-	github.com/giantswarm/clustertest v1.0.0
+	github.com/giantswarm/cluster-standup-teardown v1.7.0
+	github.com/giantswarm/clustertest v1.1.0
 	github.com/gravitational/teleport/api v0.0.0-20240607230303-55de5cf3f77f
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
@@ -62,7 +62,7 @@ require (
 	github.com/giantswarm/microerror v0.4.1 // indirect
 	github.com/giantswarm/organization-operator v1.6.3 // indirect
 	github.com/giantswarm/release-operator/v4 v4.1.0 // indirect
-	github.com/giantswarm/releases/sdk v0.2.0 // indirect
+	github.com/giantswarm/releases/sdk v0.3.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -809,10 +809,10 @@ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyT
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.1 h1:X1uzWBSrF4QsyyzaV46QkPJa+rXKBr9e0p+6nd8aw3A=
 github.com/giantswarm/apiextensions-application v0.6.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/cluster-standup-teardown v1.6.0 h1:yQgXSOh1/sELG75p/Bvb4gPp7XQ7ICVfnBbXoGRJLJg=
-github.com/giantswarm/cluster-standup-teardown v1.6.0/go.mod h1:SWAai7NpNYs4n6173h+ynAp+6f59jZPqR93mG4y6rGI=
-github.com/giantswarm/clustertest v1.0.0 h1:xwEC/gYbxw6B/Gq40ILVZZ509df85gEkQjKGFqX+5ko=
-github.com/giantswarm/clustertest v1.0.0/go.mod h1:y7LCXxNa6FVdLjzZzRwUtCTxuQfl1Undt5FsU4Wtta8=
+github.com/giantswarm/cluster-standup-teardown v1.7.0 h1:h4Kd/P1Uzh4txYGalsTahb7v7qk0itM98RZurcKy/h8=
+github.com/giantswarm/cluster-standup-teardown v1.7.0/go.mod h1:SWAai7NpNYs4n6173h+ynAp+6f59jZPqR93mG4y6rGI=
+github.com/giantswarm/clustertest v1.1.0 h1:B/FeXvl6h6C84Hx6Gxfmtmsi8zg8u/lSzpCgjbv4sv0=
+github.com/giantswarm/clustertest v1.1.0/go.mod h1:W4SqLsmi7h+u67RmMi6EwwrbjwG29BPTG2XVFX7UL+I=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=
 github.com/giantswarm/k8smetadata v0.23.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.45.0 h1:4g1Fnpkf4gjxiZtFPCEIfEnEWVIpoTXj1yij4hxaOok=
@@ -823,8 +823,8 @@ github.com/giantswarm/organization-operator v1.6.3 h1:hwfszk6pm6omT3bzJiD8+h4v5G
 github.com/giantswarm/organization-operator v1.6.3/go.mod h1:wtchBVnf4aOrZb/1pZO8szfrRPXsZbbyovfQRZPaIEo=
 github.com/giantswarm/release-operator/v4 v4.1.0 h1:8FdLoJH0pZ26lrFwodurL+FMx+W1Jf2TrOXK4x0OOVE=
 github.com/giantswarm/release-operator/v4 v4.1.0/go.mod h1:8OqMj1HZVN50NXNSA/zcLrmEUPNa+eOMHkpLHkUBf9Q=
-github.com/giantswarm/releases/sdk v0.2.0 h1:+1INdSMPIA3ZYBagwBzx0Ek1GkdhyCDqShCA4+7qZx4=
-github.com/giantswarm/releases/sdk v0.2.0/go.mod h1:EVc38EK1t7VsZPZnFFER1haLMkk7qBC6H0o8bOWWkak=
+github.com/giantswarm/releases/sdk v0.3.0 h1:EsB66UkAOOqDikOjGDNWju8/eMk5wyG5IA6yLPookUQ=
+github.com/giantswarm/releases/sdk v0.3.0/go.mod h1:EVc38EK1t7VsZPZnFFER1haLMkk7qBC6H0o8bOWWkak=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -72,10 +72,10 @@ func Run(cfg *TestConfig) {
 			applyCtx, cancelApplyCtx := context.WithTimeout(state.GetContext(), 20*time.Minute)
 			defer cancelApplyCtx()
 
-			_, err := state.GetFramework().ApplyCluster(applyCtx, cluster)
-			Expect(err).NotTo(HaveOccurred())
-
 			builtCluster, _ := cluster.Build()
+
+			_, err := state.GetFramework().ApplyBuiltCluster(applyCtx, builtCluster)
+			Expect(err).NotTo(HaveOccurred())
 
 			skipDefaultAppsApp, err := cluster.UsesUnifiedClusterApp()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### What this PR does

Switch to using new `ApplyBuiltCluster` in upgrade tests to avoid building the cluster twice.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
