### PR TITLE
Fixes unnecessary acronyms

### DIFF
--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -35,11 +35,11 @@ func runBasic() {
 			}
 		})
 
-		It("should be able to connect to MC cluster", FlakeAttempts(3), func() {
+		It("should be able to connect to management cluster", FlakeAttempts(3), func() {
 			Expect(state.GetFramework().MC().CheckConnection()).To(Succeed())
 		})
 
-		It("should be able to connect to WC cluster", FlakeAttempts(3), func() {
+		It("should be able to connect to workload cluster", FlakeAttempts(3), func() {
 			Expect(wcClient.CheckConnection()).To(Succeed())
 		})
 

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -35,7 +35,7 @@ func runBasic() {
 			}
 		})
 
-		It("should be able to connect to management cluster", FlakeAttempts(3), func() {
+		It("should be able to connect to the management cluster", FlakeAttempts(3), func() {
 			Expect(state.GetFramework().MC().CheckConnection()).To(Succeed())
 		})
 

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -39,7 +39,7 @@ func runBasic() {
 			Expect(state.GetFramework().MC().CheckConnection()).To(Succeed())
 		})
 
-		It("should be able to connect to workload cluster", FlakeAttempts(3), func() {
+		It("should be able to connect to the workload cluster", FlakeAttempts(3), func() {
 			Expect(wcClient.CheckConnection()).To(Succeed())
 		})
 


### PR DESCRIPTION
/run cluster-test-suites
