### PR TITLE
Improve CAPA upgrade tests reliability and reorder common tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Split common `basic` tests into `cluster basic` and `workload basic`.
+- Reorder common tests, so instead of running `default apps` and then `basic`, now it first runs `cluster basic`, then `default apps`, and then `workload basic`.
+- Run all common tests before the upgrade in the upgrade suite.
+- Increase node pool minSize from 2 to 3 in the CAPA upgrade suite, as we have noticed that 2 nodes are not enough for all the Pods after teh upgrade, and cluster-autoscaler does not scale up the cluster quickly enough for the test to pass.
+
+### Removed
+
+- Remove node checks in the upgrade test, because the nodes are checked in the common tests before and after the upgrade.
+
 ## [1.46.0] - 2024-06-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Remove node checks in the upgrade test, because the nodes are checked in the common tests before and after the upgrade.
+- Remove node checks in the CAPA upgrade suite, because the nodes are checked in the common tests before and after the upgrade.
 
 ## [1.46.0] - 2024-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reorder common tests, so instead of running `default apps` and then `basic`, now it first runs `cluster basic`, then `default apps`, and then `workload basic`.
 - Run all common tests before the upgrade in the CAPA upgrade suite.
 - Increase node pool minSize from 2 to 3 in the CAPA upgrade suite, as we have noticed that 2 nodes are not enough for all the Pods after teh upgrade, and cluster-autoscaler does not scale up the cluster quickly enough for the test to pass.
+- Run CAPA standard tests in order.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Split common `basic` tests into `cluster basic` and `workload basic`.
 - Reorder common tests, so instead of running `default apps` and then `basic`, now it first runs `cluster basic`, then `default apps`, and then `workload basic`.
-- Run all common tests before the upgrade in the upgrade suite.
+- Run all common tests before the upgrade in the CAPA upgrade suite.
 - Increase node pool minSize from 2 to 3 in the CAPA upgrade suite, as we have noticed that 2 nodes are not enough for all the Pods after teh upgrade, and cluster-autoscaler does not scale up the cluster quickly enough for the test to pass.
 
 ### Removed

--- a/internal/common/clusterbasic.go
+++ b/internal/common/clusterbasic.go
@@ -1,0 +1,129 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/cluster-test-suites/internal/state"
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/client"
+	"github.com/giantswarm/clustertest/pkg/logger"
+	"github.com/giantswarm/clustertest/pkg/wait"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func runClusterBasic() {
+	Context("cluster basic", func() {
+		var wcClient *client.Client
+
+		BeforeEach(func() {
+			var err error
+
+			wcClient, err = state.GetFramework().WC(state.GetCluster().Name)
+			if err != nil {
+				Fail(err.Error())
+			}
+		})
+
+		It("should be able to connect to MC cluster", FlakeAttempts(3), func() {
+			Expect(state.GetFramework().MC().CheckConnection()).To(Succeed())
+		})
+
+		It("should be able to connect to WC cluster", FlakeAttempts(3), func() {
+			Expect(wcClient.CheckConnection()).To(Succeed())
+		})
+
+		It("has all the control-plane nodes running", func() {
+			replicas, err := state.GetFramework().GetExpectedControlPlaneReplicas(state.GetContext(), state.GetCluster().Name, state.GetCluster().GetNamespace())
+			Expect(err).NotTo(HaveOccurred())
+
+			// Skip this test is the cluster is a managed cluster (e.g. EKS)
+			if replicas == 0 {
+				Skip("ControlPlane is not supported.")
+			}
+
+			wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(wait.Consistent(CheckControlPlaneNodesReady(wcClient, int(replicas)), 12, 5*time.Second)).
+				WithTimeout(15 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+
+		It("has all the worker nodes running", func() {
+			values := &application.ClusterValues{}
+			err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
+			Expect(err).NotTo(HaveOccurred())
+
+			wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(wait.Consistent(CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
+				WithTimeout(15 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+
+		It("has Cluster Ready condition with Status='True'", func() {
+			mcClient := state.GetFramework().MC()
+			cluster := state.GetCluster()
+			Eventually(wait.IsClusterConditionSet(state.GetContext(), mcClient, cluster.Name, cluster.GetNamespace(), capi.ReadyCondition, corev1.ConditionTrue, "")).
+				WithTimeout(15 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(BeTrue())
+		})
+	})
+}
+
+func CheckControlPlaneNodesReady(wcClient *client.Client, expectedNodes int) func() error {
+	controlPlaneFunc := wait.AreNumNodesReady(context.Background(), wcClient, expectedNodes, &cr.MatchingLabels{"node-role.kubernetes.io/control-plane": ""})
+
+	return func() error {
+		ok, err := controlPlaneFunc()
+		if !ok {
+			return fmt.Errorf("unexpected number of nodes")
+		}
+		return err
+	}
+}
+
+func CheckWorkerNodesReady(wcClient *client.Client, values *application.ClusterValues) func() error {
+	minNodes := 0
+	maxNodes := 0
+	for _, pool := range values.NodePools {
+		if pool.Replicas > 0 {
+			minNodes += pool.Replicas
+			maxNodes += pool.Replicas
+			continue
+		}
+
+		minNodes += pool.MinSize
+		maxNodes += pool.MaxSize
+	}
+	expectedNodes := wait.Range{
+		Min: minNodes,
+		Max: maxNodes,
+	}
+
+	workersFunc := wait.AreNumNodesReadyWithinRange(context.Background(), wcClient, expectedNodes, client.DoesNotHaveLabels{"node-role.kubernetes.io/control-plane"})
+
+	return func() error {
+		ok, err := workersFunc()
+		if err != nil {
+			logger.Log("failed to get nodes: %s", err)
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("unexpected number of nodes")
+		}
+		return nil
+	}
+}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -9,8 +9,9 @@ type TestConfig struct {
 }
 
 func Run(cfg *TestConfig) {
+	runClusterBasic()
 	runApps()
-	runBasic()
+	runWorkloadBasic()
 	runCertManager()
 	runDNS(cfg.BastionSupported)
 	runMetrics(cfg.ControlPlaneMetricsSupported)

--- a/internal/common/workloadbasic.go
+++ b/internal/common/workloadbasic.go
@@ -7,11 +7,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
-	cr "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/cluster-test-suites/internal/state"
-	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/client"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/wait"
@@ -20,8 +17,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func runBasic() {
-	Context("basic", func() {
+func runWorkloadBasic() {
+	Context("workload basic", func() {
 		var wcClient *client.Client
 
 		BeforeEach(func() {
@@ -31,46 +28,6 @@ func runBasic() {
 			if err != nil {
 				Fail(err.Error())
 			}
-		})
-
-		It("should be able to connect to MC cluster", FlakeAttempts(3), func() {
-			Expect(state.GetFramework().MC().CheckConnection()).To(Succeed())
-		})
-
-		It("should be able to connect to WC cluster", FlakeAttempts(3), func() {
-			Expect(wcClient.CheckConnection()).To(Succeed())
-		})
-
-		It("has all the control-plane nodes running", func() {
-			replicas, err := state.GetFramework().GetExpectedControlPlaneReplicas(state.GetContext(), state.GetCluster().Name, state.GetCluster().GetNamespace())
-			Expect(err).NotTo(HaveOccurred())
-
-			// Skip this test is the cluster is a managed cluster (e.g. EKS)
-			if replicas == 0 {
-				Skip("ControlPlane is not supported.")
-			}
-
-			wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(wait.Consistent(CheckControlPlaneNodesReady(wcClient, int(replicas)), 12, 5*time.Second)).
-				WithTimeout(15 * time.Minute).
-				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
-		})
-
-		It("has all the worker nodes running", func() {
-			values := &application.ClusterValues{}
-			err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
-			Expect(err).NotTo(HaveOccurred())
-
-			wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(wait.Consistent(CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
-				WithTimeout(15 * time.Minute).
-				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
 		})
 
 		It("has all its Deployments Ready (means all replicas are running)", func() {
@@ -100,61 +57,7 @@ func runBasic() {
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
-
-		It("has Cluster Ready condition with Status='True'", func() {
-			mcClient := state.GetFramework().MC()
-			cluster := state.GetCluster()
-			Eventually(wait.IsClusterConditionSet(state.GetContext(), mcClient, cluster.Name, cluster.GetNamespace(), capi.ReadyCondition, corev1.ConditionTrue, "")).
-				WithTimeout(15 * time.Minute).
-				WithPolling(wait.DefaultInterval).
-				Should(BeTrue())
-		})
 	})
-}
-
-func CheckControlPlaneNodesReady(wcClient *client.Client, expectedNodes int) func() error {
-	controlPlaneFunc := wait.AreNumNodesReady(context.Background(), wcClient, expectedNodes, &cr.MatchingLabels{"node-role.kubernetes.io/control-plane": ""})
-
-	return func() error {
-		ok, err := controlPlaneFunc()
-		if !ok {
-			return fmt.Errorf("unexpected number of nodes")
-		}
-		return err
-	}
-}
-
-func CheckWorkerNodesReady(wcClient *client.Client, values *application.ClusterValues) func() error {
-	minNodes := 0
-	maxNodes := 0
-	for _, pool := range values.NodePools {
-		if pool.Replicas > 0 {
-			minNodes += pool.Replicas
-			maxNodes += pool.Replicas
-			continue
-		}
-
-		minNodes += pool.MinSize
-		maxNodes += pool.MaxSize
-	}
-	expectedNodes := wait.Range{
-		Min: minNodes,
-		Max: maxNodes,
-	}
-
-	workersFunc := wait.AreNumNodesReadyWithinRange(context.Background(), wcClient, expectedNodes, client.DoesNotHaveLabels{"node-role.kubernetes.io/control-plane"})
-
-	return func() error {
-		ok, err := workersFunc()
-		if err != nil {
-			logger.Log("failed to get nodes: %s", err)
-			return err
-		}
-		if !ok {
-			return fmt.Errorf("unexpected number of nodes")
-		}
-		return nil
-	}
 }
 
 func checkAllPodsSuccessfulPhase(wcClient *client.Client) func() error {

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -12,7 +12,6 @@ import (
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/wait"
 
-	"github.com/giantswarm/cluster-test-suites/internal/common"
 	"github.com/giantswarm/cluster-test-suites/internal/state"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -37,33 +36,6 @@ func Run(cfg *TestConfig) {
 
 		BeforeEach(func() {
 			cluster = state.GetCluster()
-		})
-
-		It("has all the control-plane nodes running", func() {
-			replicas, err := state.GetFramework().GetExpectedControlPlaneReplicas(state.GetContext(), state.GetCluster().Name, state.GetCluster().GetNamespace())
-			Expect(err).NotTo(HaveOccurred())
-
-			wcClient, err := state.GetFramework().WC(cluster.Name)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, int(replicas)), 12, 5*time.Second)).
-				WithTimeout(cfg.ControlPlaneNodesTimeout).
-				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
-		})
-
-		It("has all the worker nodes running", func() {
-			values := &application.ClusterValues{}
-			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.GetNamespace(), values)
-			Expect(err).NotTo(HaveOccurred())
-
-			wcClient, err := state.GetFramework().WC(cluster.Name)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(wait.Consistent(common.CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
-				WithTimeout(cfg.WorkerNodesTimeout).
-				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
 		})
 
 		It("should apply new version successfully", func() {
@@ -144,33 +116,6 @@ func Run(cfg *TestConfig) {
 				30*time.Minute,
 				30*time.Second,
 			).Should(BeTrue())
-		})
-
-		It("has all the control-plane nodes running", func() {
-			replicas, err := state.GetFramework().GetExpectedControlPlaneReplicas(state.GetContext(), state.GetCluster().Name, state.GetCluster().GetNamespace())
-			Expect(err).NotTo(HaveOccurred())
-
-			wcClient, err := state.GetFramework().WC(cluster.Name)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, int(replicas)), 12, 5*time.Second)).
-				WithTimeout(cfg.ControlPlaneNodesTimeout).
-				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
-		})
-
-		It("has all the worker nodes running", func() {
-			values := &application.ClusterValues{}
-			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.GetNamespace(), values)
-			Expect(err).NotTo(HaveOccurred())
-
-			wcClient, err := state.GetFramework().WC(cluster.Name)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(wait.Consistent(common.CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
-				WithTimeout(cfg.WorkerNodesTimeout).
-				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
 		})
 	})
 }

--- a/providers/capa/standard/capa_test.go
+++ b/providers/capa/standard/capa_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = Describe("Common tests", func() {
+var _ = Describe("Common tests", Ordered, func() {
 	common.Run(&common.TestConfig{
 		AutoScalingSupported:         true,
 		BastionSupported:             false,

--- a/providers/capa/upgrade/capa_test.go
+++ b/providers/capa/upgrade/capa_test.go
@@ -8,9 +8,19 @@ import (
 )
 
 var _ = Describe("Basic upgrade test", Ordered, func() {
+	// Run common tests before the upgrade is started, so we ensure that the cluster is fully ready
+	// before we do the upgrade.
+	common.Run(&common.TestConfig{
+		AutoScalingSupported:         true,
+		BastionSupported:             false,
+		TeleportSupported:            true,
+		ExternalDnsSupported:         true,
+		ControlPlaneMetricsSupported: true,
+	})
+
 	upgrade.Run(upgrade.NewTestConfigWithDefaults())
 
-	// Finally run the common tests after upgrade is completed
+	// Finally run the common tests again after upgrade is completed
 	common.Run(&common.TestConfig{
 		AutoScalingSupported:         true,
 		BastionSupported:             false,

--- a/providers/capa/upgrade/test_data/cluster_values.yaml
+++ b/providers/capa/upgrade/test_data/cluster_values.yaml
@@ -1,1 +1,11 @@
 # Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
+global:
+  nodePools:
+    # We are using a name with 10 chars which is the max number of characters allowed by our kyverno policies.
+    nodepool-0:
+      maxSize: 5
+      minSize: 3
+      rootVolumeSizeGB: 25
+      spotInstances:
+        enabled: true
+        maxPrice: 0.2960


### PR DESCRIPTION
### What this PR does

#### Changed

- Split common `basic` tests into `cluster basic` and `workload basic`.
- Reorder common tests, so instead of running `default apps` and then `basic`, now it first runs `cluster basic`, then `default apps`, and then `workload basic`.
- Run all common tests before the upgrade in the CAPA upgrade suite.
- Increase node pool minSize from 2 to 3 in the CAPA upgrade suite, as we have noticed that 2 nodes are not enough for all the Pods to be scheduled after the upgrade, and cluster-autoscaler does not scale up the cluster quickly enough for the test to pass.

#### Removed

- Remove node checks in the CAPA upgrade suite, because the nodes are checked in the common tests before and after the upgrade.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
