### PR TITLE
Improve upgrade suites reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove node checks from CAPA upgrade suite because we already check nodes in common tests after the upgrade.
 
+### Removed
+
+- Remove node checks from upgrade because we already check nodes in common tests after the upgrade.
+
 ## [1.47.0] - 2024-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove node checks from CAPA upgrade suite because we already check nodes in common tests after the upgrade.
 
-### Removed
-
-- Remove node checks from upgrade because we already check nodes in common tests after the upgrade.
-
 ## [1.47.0] - 2024-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure timeout is always reset on the context in the AfterSuite to ensure enough time is given for cleanup
 
+### Added
+
+- Test workload cluster's Deployments, DaemonSets, StatefulSets and Pods before upgrading the cluster.
+- Test if cluster is ready before upgrading the cluster (check Cluster resource Ready condition).
+
 ### Changed
 
 - Update clustertest to v1.3.0 to support releases with cluster Apps for Azure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Test if default apps are deployed before upgrading the cluster.
 - Test workload cluster's Deployments, DaemonSets, StatefulSets and Pods before upgrading the cluster.
 - Test if cluster is ready before upgrading the cluster (check Cluster resource Ready condition).
+- Test if machine pools are ready and running before upgrading the cluster.
+- Test if machine pools are ready and running in common tests.
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	k8s.io/api v0.26.15
-	k8s.io/apiextensions-apiserver v0.26.10
+	k8s.io/apiextensions-apiserver v0.26.15
 	k8s.io/apimachinery v0.26.15
 	k8s.io/client-go v0.26.15
 	sigs.k8s.io/cluster-api v1.4.0-beta.2
@@ -181,7 +181,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v3 v3.11.3 // indirect
-	k8s.io/apiserver v0.26.10 // indirect
+	k8s.io/apiserver v0.26.15 // indirect
 	k8s.io/cli-runtime v0.26.15 // indirect
 	k8s.io/cluster-bootstrap v0.25.0 // indirect
 	k8s.io/component-base v0.26.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2184,12 +2184,12 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 k8s.io/api v0.26.15 h1:tjMERUjIwkq+2UtPZL5ZbSsLkpxUv4gXWZfV5lQl+Og=
 k8s.io/api v0.26.15/go.mod h1:CtWOrFl8VLCTLolRlhbBxo4fy83tjCLEtYa5pMubIe0=
-k8s.io/apiextensions-apiserver v0.26.10 h1:wAriTUc6l7gUqJKOxhmXnYo/VNJzk4oh4QLCUR4Uq+k=
-k8s.io/apiextensions-apiserver v0.26.10/go.mod h1:N2qhlxkhJLSoC4f0M1/1lNG627b45SYqnOPEVFoQXw4=
+k8s.io/apiextensions-apiserver v0.26.15 h1:QePn6+5mihx8sXQLaOXzvF4XPv2RGGj8Pv+O4P75GPU=
+k8s.io/apiextensions-apiserver v0.26.15/go.mod h1:PbhgN0XidyF+9vCTUmNgVFK0MMEYqlHLZ4AJeBfiNMo=
 k8s.io/apimachinery v0.26.15 h1:GPxeERYBSqSZlj3xIkX4L6mBjzZ9q8JPnJ+Vj15qe+g=
 k8s.io/apimachinery v0.26.15/go.mod h1:O/uIhIOWuy6ndHqQ6qbkjD7OgeMhVtlk8+Z66ZcmJQc=
-k8s.io/apiserver v0.26.10 h1:gradpIHygzZN87yK+o6V3gpbCSF78HZ0hejLZQQwdDs=
-k8s.io/apiserver v0.26.10/go.mod h1:TGrQKQWUfQcotK3P4TtoVZxXOWklFF36QZlA5wufLs4=
+k8s.io/apiserver v0.26.15 h1:9sV2i7+A+/+YjQw9DMf7XTgbUdxtOKeTkluU7VhlD6Y=
+k8s.io/apiserver v0.26.15/go.mod h1:dLnCqVroGkCKYNobv9Nm1Ot8GzapzMOKltAlkOlzv8o=
 k8s.io/cli-runtime v0.26.15 h1:+y3am0YLVBEfe4je5taxVUM8EKQKnUqzmXBdn3Ytxko=
 k8s.io/cli-runtime v0.26.15/go.mod h1:AXABAdbXP0xeIJV4SpJ1caMR7FY8GjXTxMsJ5/1iMF0=
 k8s.io/client-go v0.26.15 h1:A2Yav2v+VZQfpEsf5ESFp2Lqq5XACKBDrwkG+jEtOg0=

--- a/internal/common/apps.go
+++ b/internal/common/apps.go
@@ -21,7 +21,7 @@ const (
 	DefaultDeployAppsTimeout    = 15 * time.Minute
 )
 
-func runApps() {
+func RunApps() {
 	Context("default apps", func() {
 		It("all default apps are deployed without issues", func() {
 			skipDefaultAppsApp, err := state.GetCluster().UsesUnifiedClusterApp()

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -109,6 +109,15 @@ func runBasic() {
 				WithPolling(wait.DefaultInterval).
 				Should(BeTrue())
 		})
+
+		It("has all machine pools ready and running", func() {
+			mcClient := state.GetFramework().MC()
+			cluster := state.GetCluster()
+			Eventually(wait.MachinePoolsAreReadyAndRunning(state.GetContext(), mcClient, cluster.Name, cluster.GetNamespace())).
+				WithTimeout(30 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(BeTrue())
+		})
 	})
 }
 

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -74,28 +74,28 @@ func runBasic() {
 		})
 
 		It("has all its Deployments Ready (means all replicas are running)", func() {
-			Eventually(wait.Consistent(checkAllDeploymentsReady(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(CheckAllDeploymentsReady(wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
 
 		It("has all its StatefulSets Ready (means all replicas are running)", func() {
-			Eventually(wait.Consistent(checkAllStatefulSetsReady(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(CheckAllStatefulSetsReady(wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
 
 		It("has all its DaemonSets Ready (means all daemon pods are running)", func() {
-			Eventually(wait.Consistent(checkAllDaemonSetsReady(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(CheckAllDaemonSetsReady(wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
 
 		It("has all of its Pods in the Running state", func() {
-			Eventually(wait.Consistent(checkAllPodsSuccessfulPhase(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(CheckAllPodsSuccessfulPhase(wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
@@ -157,7 +157,7 @@ func CheckWorkerNodesReady(wcClient *client.Client, values *application.ClusterV
 	}
 }
 
-func checkAllPodsSuccessfulPhase(wcClient *client.Client) func() error {
+func CheckAllPodsSuccessfulPhase(wcClient *client.Client) func() error {
 	return func() error {
 		podList := &corev1.PodList{}
 		err := wcClient.List(context.Background(), podList)
@@ -178,7 +178,7 @@ func checkAllPodsSuccessfulPhase(wcClient *client.Client) func() error {
 	}
 }
 
-func checkAllDeploymentsReady(wcClient *client.Client) func() error {
+func CheckAllDeploymentsReady(wcClient *client.Client) func() error {
 	return func() error {
 		deploymentList := &appsv1.DeploymentList{}
 		err := wcClient.List(context.Background(), deploymentList)
@@ -200,7 +200,7 @@ func checkAllDeploymentsReady(wcClient *client.Client) func() error {
 	}
 }
 
-func checkAllStatefulSetsReady(wcClient *client.Client) func() error {
+func CheckAllStatefulSetsReady(wcClient *client.Client) func() error {
 	return func() error {
 		statefulSetList := &appsv1.StatefulSetList{}
 		err := wcClient.List(context.Background(), statefulSetList)
@@ -222,7 +222,7 @@ func checkAllStatefulSetsReady(wcClient *client.Client) func() error {
 	}
 }
 
-func checkAllDaemonSetsReady(wcClient *client.Client) func() error {
+func CheckAllDaemonSetsReady(wcClient *client.Client) func() error {
 	return func() error {
 		daemonSetList := &appsv1.DaemonSetList{}
 		err := wcClient.List(context.Background(), daemonSetList)

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -115,7 +115,7 @@ func runBasic() {
 			mcClient := state.GetFramework().MC()
 			cluster := state.GetCluster()
 
-			machinePools, err := state.GetFramework().GetMachinePools(context.Background(), cluster.Name, cluster.GetNamespace()
+			machinePools, err := state.GetFramework().GetMachinePools(context.Background(), cluster.Name, cluster.GetNamespace())
 			Expect(err).NotTo(HaveOccurred())
 			if len(machinePools) == 0 {
 				Skip("Machine pools are not found")

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -9,7 +9,7 @@ type TestConfig struct {
 }
 
 func Run(cfg *TestConfig) {
-	runApps()
+	RunApps()
 	runBasic()
 	runCertManager()
 	runDNS(cfg.BastionSupported)

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -42,9 +42,7 @@ func Run(cfg *TestConfig) {
 			var err error
 			cluster = state.GetCluster()
 			wcClient, err = state.GetFramework().WC(cluster.Name)
-			if err != nil {
-				Fail(err.Error())
-			}
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("has all the control-plane nodes running", func() {

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -106,10 +106,10 @@ func Run(cfg *TestConfig) {
 		It("has all machine pools ready and running", func() {
 			mcClient := state.GetFramework().MC()
 			cluster := state.GetCluster()
-			Eventually(wait.MachinePoolsAreReadyAndRunning(state.GetContext(), mcClient, cluster.Name, cluster.GetNamespace())).
+			Eventually(wait.Consistent(common.CheckMachinePoolsReadyAndRunning(mcClient, cluster.Name, cluster.GetNamespace()), 10, time.Second)).
 				WithTimeout(30 * time.Minute).
 				WithPolling(wait.DefaultInterval).
-				Should(BeTrue())
+				Should(Succeed())
 		})
 
 		It("should apply new version successfully", func() {

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -113,8 +113,7 @@ func Run(cfg *TestConfig) {
 				Skip("Machine pools are not found")
 			}
 
-			logger.Log("checking machine pools for cluster %s/%s", cluster.GetNamespace(), cluster.Name)
-			Eventually(wait.Consistent(common.CheckMachinePoolsReadyAndRunning(mcClient, cluster.Name, cluster.GetNamespace()), 10, time.Second)).
+			Eventually(wait.Consistent(common.CheckMachinePoolsReadyAndRunning(mcClient, cluster.Name, cluster.GetNamespace()), 5, 5*time.Second)).
 				WithTimeout(30 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -106,6 +106,14 @@ func Run(cfg *TestConfig) {
 		It("has all machine pools ready and running", func() {
 			mcClient := state.GetFramework().MC()
 			cluster := state.GetCluster()
+
+			machinePools, err := state.GetFramework().GetMachinePools(context.Background(), cluster.Name, cluster.GetNamespace())
+			Expect(err).NotTo(HaveOccurred())
+			if len(machinePools) == 0 {
+				Skip("Machine pools are not found")
+			}
+
+			logger.Log("checking machine pools for cluster %s/%s", cluster.GetNamespace(), cluster.Name)
 			Eventually(wait.Consistent(common.CheckMachinePoolsReadyAndRunning(mcClient, cluster.Name, cluster.GetNamespace()), 10, time.Second)).
 				WithTimeout(30 * time.Minute).
 				WithPolling(wait.DefaultInterval).

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -103,6 +103,15 @@ func Run(cfg *TestConfig) {
 				Should(BeTrue())
 		})
 
+		It("has all machine pools ready and running", func() {
+			mcClient := state.GetFramework().MC()
+			cluster := state.GetCluster()
+			Eventually(wait.MachinePoolsAreReadyAndRunning(state.GetContext(), mcClient, cluster.Name, cluster.GetNamespace())).
+				WithTimeout(30 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(BeTrue())
+		})
+
 		It("should apply new version successfully", func() {
 			// Set app versions to `""` so that it makes use of the overrides set in the `E2E_OVERRIDE_VERSIONS` environment var
 			cluster = cluster.WithAppVersions("", "")

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	kubeadm "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
 
 	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/client"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/wait"
 
@@ -34,16 +36,19 @@ func NewTestConfigWithDefaults() *TestConfig {
 func Run(cfg *TestConfig) {
 	Context("upgrade", func() {
 		var cluster *application.Cluster
+		var wcClient *client.Client
 
 		BeforeEach(func() {
+			var err error
 			cluster = state.GetCluster()
+			wcClient, err = state.GetFramework().WC(cluster.Name)
+			if err != nil {
+				Fail(err.Error())
+			}
 		})
 
 		It("has all the control-plane nodes running", func() {
 			replicas, err := state.GetFramework().GetExpectedControlPlaneReplicas(state.GetContext(), state.GetCluster().Name, state.GetCluster().GetNamespace())
-			Expect(err).NotTo(HaveOccurred())
-
-			wcClient, err := state.GetFramework().WC(cluster.Name)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, int(replicas)), 12, 5*time.Second)).
@@ -57,13 +62,47 @@ func Run(cfg *TestConfig) {
 			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.GetNamespace(), values)
 			Expect(err).NotTo(HaveOccurred())
 
-			wcClient, err := state.GetFramework().WC(cluster.Name)
-			Expect(err).NotTo(HaveOccurred())
-
 			Eventually(wait.Consistent(common.CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
 				WithTimeout(cfg.WorkerNodesTimeout).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
+		})
+
+		It("has all its Deployments Ready (means all replicas are running)", func() {
+			Eventually(wait.Consistent(common.CheckAllDeploymentsReady(wcClient), 10, time.Second)).
+				WithTimeout(15 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+
+		It("has all its StatefulSets Ready (means all replicas are running)", func() {
+			Eventually(wait.Consistent(common.CheckAllStatefulSetsReady(wcClient), 10, time.Second)).
+				WithTimeout(15 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+
+		It("has all its DaemonSets Ready (means all daemon pods are running)", func() {
+			Eventually(wait.Consistent(common.CheckAllDaemonSetsReady(wcClient), 10, time.Second)).
+				WithTimeout(15 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+
+		It("has all of its Pods in the Running state", func() {
+			Eventually(wait.Consistent(common.CheckAllPodsSuccessfulPhase(wcClient), 10, time.Second)).
+				WithTimeout(15 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+
+		It("has Cluster Ready condition with Status='True'", func() {
+			mcClient := state.GetFramework().MC()
+			cluster := state.GetCluster()
+			Eventually(wait.IsClusterConditionSet(state.GetContext(), mcClient, cluster.Name, cluster.GetNamespace(), capi.ReadyCondition, corev1.ConditionTrue, "")).
+				WithTimeout(15 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(BeTrue())
 		})
 
 		It("should apply new version successfully", func() {


### PR DESCRIPTION
### What this PR does

Alernative to https://github.com/giantswarm/cluster-test-suites/pull/339, just with less changes.

> [!NOTE]
> Currently before we upgrade the cluster, we just check if the nodes are ready. Just checking the nodes is IMO far from enough, and below additions are the bare minimum we should add now as these fix the issues that me and other folks have consistently noticed in different test runs (meaning more checks should be added in addition to these two below).

> [!WARNING]
> There is a change here in the PR to rename `runApps()` in `common` package to `RunApps()`, so we can reuse the app tests in upgrade tests as well (in addition to apps being tested in `common` tests). This is breaking the code structure as app tests (from `runApps()`) should be executed as a part of `common.Run(cfg)` call. I will open an issue to refactor this a bit, so we have app tests in a separate package.

#### Added

- Test if cluster is ready before upgrading the cluster, i.e. check if Cluster resource has Ready condition with status `True`. When it comes to Cluster API, this is sort of a quick catch-all test, as Ready condition is a summary of all other conditions in CAPI and CAPA resources, so it is a quick check to verify if something is not ready in the cluster. In case Ready condition has a status `False`, that means that some fundamental part of the cluster is not ready, and therefore we should know that and wait for it to get ready before upgrading the cluster.
- Test if machine pools are ready and running before upgrading the cluster.
- Test if default apps are deployed before upgrading the cluster.
- Test workload cluster's Deployments, DaemonSets, StatefulSets and Pods before upgrading the cluster because we test these after the upgrade, so we should make sure that they worked before the upgrade, as the upgrade can impact them.
- Test if machine pools are ready and running in common tests.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
