### PR TITLE
Increase node pool min size from 2 to 3 for CAPA upgrade test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated teleport api module to latest available.
+- Increase node pool min size from 2 to 3 for CAPA upgrade test.
 
 ## [1.47.0] - 2024-06-14
 

--- a/providers/capa/upgrade/test_data/cluster_values.yaml
+++ b/providers/capa/upgrade/test_data/cluster_values.yaml
@@ -1,1 +1,9 @@
-# Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
+global:
+  nodePools:
+    # Here we override the default values from cluster-standup-teardown and increase min size from 2 to 3 because of
+    # issues discovered on 14/06/2024, where after the upgrade cluster-autoscaler scales down the cluster to min size
+    # (which is 2 by default) and after that a lot of Pods cannot be scheduled. The result is that Upgrade suite fails
+    # because WC Deployments are not ready, as test time-out passes more quickly than cluster-autoscaler can scale up
+    # the cluster.
+    nodepool-0:
+      minSize: 3


### PR DESCRIPTION
### What this PR does

#### Changed

- Increase node pool min size from 2 to 3 for CAPA upgrade test.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
