### PR TITLE
Remove node checks from CAPA upgrade suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated teleport api module to latest available.
 
+### Removed
+
+- Remove node checks from CAPA upgrade suite because we already check nodes in common tests after the upgrade.
+
 ## [1.47.0] - 2024-06-14
 
 ### Added

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -145,32 +145,5 @@ func Run(cfg *TestConfig) {
 				30*time.Second,
 			).Should(BeTrue())
 		})
-
-		It("has all the control-plane nodes running", func() {
-			replicas, err := state.GetFramework().GetExpectedControlPlaneReplicas(state.GetContext(), state.GetCluster().Name, state.GetCluster().GetNamespace())
-			Expect(err).NotTo(HaveOccurred())
-
-			wcClient, err := state.GetFramework().WC(cluster.Name)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, int(replicas)), 12, 5*time.Second)).
-				WithTimeout(cfg.ControlPlaneNodesTimeout).
-				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
-		})
-
-		It("has all the worker nodes running", func() {
-			values := &application.ClusterValues{}
-			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.GetNamespace(), values)
-			Expect(err).NotTo(HaveOccurred())
-
-			wcClient, err := state.GetFramework().WC(cluster.Name)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(wait.Consistent(common.CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
-				WithTimeout(cfg.WorkerNodesTimeout).
-				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
-		})
 	})
 }


### PR DESCRIPTION
### What this PR does

#### Removed

- Remove node checks from CAPA upgrade suite because we already check nodes in common tests after the upgrade.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
