### PR TITLE
Disable spot instances for CAPA upgrade suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated teleport api module to latest available.
 - Increase node pool min size from 2 to 3 for CAPA upgrade test.
+- Disable spot instances for CAPA upgrade suite, as we suspect that using spot instances is causing Upgrade suite failures lately.
 
 ### Removed
 

--- a/providers/capa/upgrade/test_data/cluster_values.yaml
+++ b/providers/capa/upgrade/test_data/cluster_values.yaml
@@ -1,9 +1,15 @@
 global:
   nodePools:
-    # Here we override the default values from cluster-standup-teardown and increase min size from 2 to 3 because of
-    # issues discovered on 14/06/2024, where after the upgrade cluster-autoscaler scales down the cluster to min size
-    # (which is 2 by default) and after that a lot of Pods cannot be scheduled. The result is that Upgrade suite fails
-    # because WC Deployments are not ready, as test time-out passes more quickly than cluster-autoscaler can scale up
-    # the cluster.
+    # Here we override the default values from cluster-standup-teardown and make the following changes:
+    #
+    # 1. Increase min size from 2 to 3 because of issues discovered on 14/06/2024, where after the upgrade
+    #    cluster-autoscaler scales down the cluster to min size (which is 2 by default) and after that a lot of Pods
+    #    cannot be scheduled. The result is that Upgrade suite fails because WC Deployments are not ready, as test
+    #    time-out passes more quickly than cluster-autoscaler can scale up the cluster.
+    #
+    # 2. Disable spot instances for CAPA upgrade suite, as we suspect that using spot instances is causing Upgrade suite
+    #    failures. E.g. node pool gets scaled down to 1 instance only after the upgrade, while the min size is 3.
     nodepool-0:
       minSize: 3
+      spotInstances:
+        enabled: false


### PR DESCRIPTION
### What this PR does

- Disable spot instances for CAPA upgrade suite, as we suspect that using spot instances is causing Upgrade suite failures lately.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
