### PR TITLE
Reset context timeout in AfterSuite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure timeout is always reset on the context in the AfterSuite to ensure enough time is given for cleanup
+
 ### Changed
 
 - Updated teleport api module to latest available.

--- a/internal/suite/setup.go
+++ b/internal/suite/setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,6 +48,11 @@ func Setup(isUpgrade bool, clusterBuilder cb.ClusterBuilder, clusterReadyFns ...
 		if isUpgrade && strings.TrimSpace(os.Getenv("E2E_OVERRIDE_VERSIONS")) == "" {
 			return
 		}
+
+		// Ensure we reset the context timeout to make sure we allow plenty of time to clean up
+		ctx := state.GetContext()
+		ctx, _ = context.WithTimeout(ctx, 1*time.Hour)
+		state.SetContext(ctx)
 
 		Expect(state.GetFramework().DeleteCluster(state.GetContext(), state.GetCluster())).To(Succeed())
 	})


### PR DESCRIPTION
### What this PR does

Ensure that the timeout on the context passed in to the delete function in AfterSuite is always a value long enough to handle all cleanup needed.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
