### PR TITLE
Add extra logging to scale test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove node checks from CAPA upgrade suite because we already check nodes in common tests after the upgrade.
 
+### Added
+
+- Additional logging added to the deployment scale test to display conditions of the pods and taints of the worker nodes
+
 ## [1.47.0] - 2024-06-14
 
 ### Added


### PR DESCRIPTION
### What this PR does

Towards: https://github.com/giantswarm/giantswarm/issues/31013 & https://github.com/giantswarm/roadmap/issues/3499

When the scale test is waiting for the expected number of replicas to be available we now log out the conditions of all the current pods as well as the taints of all the current worker nodes. This should allow us to better debug failures without needing to access the WC.

#### Example output

```
  {"level":"info","ts":"2024-06-20T09:20:23+01:00","msg":"Checking for increased replicas. Expected: 3, Actual: 2"}
  {"level":"info","ts":"2024-06-20T09:20:23+01:00","msg":"Condition messages from non-running deployment pods: [scale-hello-world-6d586889c8-g2mlq=0/6 nodes are available: 1 node(s) had untolerated taint {node.cluster.x-k8s.io/uninitialized: }, 2 node(s) didn't match pod anti-affinity rules, 3 node(s) had untolerated taint {node-role.kubernetes.io/control-plane: }. preemption: 0/6 nodes are available: 2 No preemption victims found for incoming pod, 4 Preemption is not helpful for scheduling.]"}
  {"level":"info","ts":"2024-06-20T09:20:23+01:00","msg":"There are currently '3' worker nodes"}
  {"level":"info","ts":"2024-06-20T09:20:23+01:00","msg":"Worker node status: NodeName='ip-10-0-125-70.eu-west-2.compute.internal', Taints='[]'"}
  {"level":"info","ts":"2024-06-20T09:20:23+01:00","msg":"Worker node status: NodeName='ip-10-0-139-210.eu-west-2.compute.internal', Taints='[]'"}
  {"level":"info","ts":"2024-06-20T09:20:23+01:00","msg":"Worker node status: NodeName='ip-10-0-221-157.eu-west-2.compute.internal', Taints='[{node.cluster.x-k8s.io/uninitialized  NoSchedule <nil>}]'"}
  {"level":"info","ts":"2024-06-20T09:20:33+01:00","msg":"Checking for increased replicas. Expected: 3, Actual: 2"}
  {"level":"info","ts":"2024-06-20T09:20:33+01:00","msg":"Condition messages from non-running deployment pods: [scale-hello-world-6d586889c8-g2mlq=0/6 nodes are available: 1 node(s) had untolerated taint {node.cluster.x-k8s.io/uninitialized: }, 2 node(s) didn't match pod anti-affinity rules, 3 node(s) had untolerated taint {node-role.kubernetes.io/control-plane: }. preemption: 0/6 nodes are available: 2 No preemption victims found for incoming pod, 4 Preemption is not helpful for scheduling.]"}
  {"level":"info","ts":"2024-06-20T09:20:33+01:00","msg":"There are currently '3' worker nodes"}
  {"level":"info","ts":"2024-06-20T09:20:33+01:00","msg":"Worker node status: NodeName='ip-10-0-125-70.eu-west-2.compute.internal', Taints='[]'"}
  {"level":"info","ts":"2024-06-20T09:20:33+01:00","msg":"Worker node status: NodeName='ip-10-0-139-210.eu-west-2.compute.internal', Taints='[]'"}
  {"level":"info","ts":"2024-06-20T09:20:33+01:00","msg":"Worker node status: NodeName='ip-10-0-221-157.eu-west-2.compute.internal', Taints='[{node.cluster.x-k8s.io/uninitialized  NoSchedule <nil>}]'"}
  {"level":"info","ts":"2024-06-20T09:20:43+01:00","msg":"Checking for increased replicas. Expected: 3, Actual: 3"}
• [128.981 seconds]
```

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
