### PR TITLE
Added more logging to ClusterIssuer test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Included extra logging in ClusterIssuer test case to output the status and failing events of the post-install Helm Job.
+
 ## [1.49.0] - 2024-06-21
 
 ### Changed

--- a/internal/common/certmanager.go
+++ b/internal/common/certmanager.go
@@ -10,8 +10,14 @@ import (
 	"github.com/giantswarm/clustertest/pkg/logger"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+
 	cr "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -33,7 +39,7 @@ func runCertManager() {
 
 		It("cert-manager default ClusterIssuers are present and ready", func() {
 			for _, clusterIssuerName := range clusterIssuers {
-				Eventually(checkClusterIssuer(wcClient, clusterIssuerName)).
+				Eventually(checkClusterIssuer(state.GetContext(), wcClient, clusterIssuerName)).
 					WithTimeout(120 * time.Second).
 					WithPolling(1 * time.Second).
 					Should(Succeed())
@@ -42,7 +48,7 @@ func runCertManager() {
 	})
 }
 
-func checkClusterIssuer(wcClient *client.Client, clusterIssuerName string) func() error {
+func checkClusterIssuer(ctx context.Context, wcClient *client.Client, clusterIssuerName string) func() error {
 	return func() error {
 		logger.Log("Checking ClusterIssuer '%s'", clusterIssuerName)
 		// Using a unstructured object.
@@ -52,10 +58,46 @@ func checkClusterIssuer(wcClient *client.Client, clusterIssuerName string) func(
 			Kind:    "ClusterIssuer",
 			Version: "v1",
 		})
-		err := wcClient.Get(context.Background(), cr.ObjectKey{
-			Name: clusterIssuerName,
-		}, u)
+		err := wcClient.Get(ctx, cr.ObjectKey{Name: clusterIssuerName}, u)
 		if err != nil {
+			if errors.IsNotFound(err) {
+				// Cluster Issuer was not found so we'll check the status of the Job that creates it
+				var nestedErr error
+				logger.Log("ClusterIssuer '%s' is not yet found", clusterIssuerName)
+
+				// Get status of cluster issuer post-install Job
+				clusterIssuerJob := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cert-manager-giantswarm-clusterissuer",
+						Namespace: "kube-system",
+					},
+				}
+				nestedErr = wcClient.Get(ctx, cr.ObjectKeyFromObject(clusterIssuerJob), clusterIssuerJob)
+				if nestedErr != nil {
+					logger.Log("Failed to get cluster issuer Job, it may have already completed: %v", nestedErr)
+				} else {
+					logger.Log("Status of cluster issuer Job '%s': Succeeded:%t", clusterIssuerJob.ObjectMeta.Name, clusterIssuerJob.Status.Succeeded > 0)
+				}
+
+				// Get events related to the cluster issuer post-install Job
+				events := &corev1.EventList{}
+				nestedErr = wcClient.List(ctx, events, cr.MatchingFieldsSelector{
+					Selector: fields.AndSelectors(
+						fields.OneTermEqualSelector("involvedObject.kind", "Job"),
+						fields.OneTermEqualSelector("involvedObject.name", clusterIssuerJob.ObjectMeta.Name),
+					),
+				})
+				if nestedErr != nil {
+					logger.Log("Failed to get events for cluster issuer Job: %v", nestedErr)
+				} else {
+					for _, event := range events.Items {
+						if event.Type != corev1.EventTypeNormal {
+							logger.Log("Event: Reason='%s', Message='%s', Last Occurred='%v'", event.Reason, event.Message, event.LastTimestamp)
+						}
+					}
+				}
+			}
+
 			return err
 		}
 		logger.Log("ClusterIssuer '%s' is present", clusterIssuerName)


### PR DESCRIPTION
### What this PR does

Towards: https://github.com/giantswarm/giantswarm/issues/31013

If the ClusterIssuer is not found we will attempt to get the status of the Helm `post-install` Job and any associated non-normal events to help debug failures without needing to re-run the suite.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
