### PR TITLE
Test for hello-world ingress Certificate ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a test case to ensure the hello-world ingress has a ready Certificate
+
 ## [1.49.0] - 2024-06-21
 
 ### Changed

--- a/internal/common/hello.go
+++ b/internal/common/hello.go
@@ -248,7 +248,7 @@ func runHelloWorld(externalDnsSupported bool) {
 
 				logger.Log("Certificate '%s' is not Ready - '%s'", certificateName, conditionMessage)
 
-				return nil
+				return fmt.Errorf("Certificate is not ready")
 			}).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).

--- a/internal/common/hello.go
+++ b/internal/common/hello.go
@@ -17,6 +17,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -199,6 +201,58 @@ func runHelloWorld(externalDnsSupported bool) {
 				WithTimeout(6 * time.Minute).
 				WithPolling(5 * time.Second).
 				Should(BeTrue())
+		})
+
+		It("should have a ready Certificate generated", func() {
+			wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			certificateName := "hello-world-tls"
+			certificateNamespace := "giantswarm"
+
+			Eventually(func() error {
+				logger.Log("Checking for certificate '%s' in namespace '%s'", certificateName, certificateNamespace)
+
+				// TODO: Update `clustertest` client with cert-manager schema
+				u := &unstructured.Unstructured{}
+				u.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "cert-manager.io",
+					Kind:    "Certificate",
+					Version: "v1",
+				})
+				err := wcClient.Get(state.GetContext(), ctrl.ObjectKey{Name: certificateName, Namespace: certificateNamespace}, u)
+				if err != nil {
+					return err
+				}
+
+				conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+				if err != nil {
+					return err
+				}
+				if !found {
+					return fmt.Errorf("Certificate '%s' does not have status.conditions", certificateName)
+				}
+
+				conditionMessage := "(no status message found)"
+				for _, condition := range conditions {
+					c := condition.(map[string]interface{})
+					conditionType := c["type"]
+					status := c["status"]
+					if conditionType == "Ready" && status == "True" {
+						logger.Log("Found status.condition with type '%s' and status '%s' in Certificate '%s'", conditionType, status, certificateName)
+						return nil
+					} else if conditionType == "Ready" {
+						conditionMessage = c["message"].(string)
+					}
+				}
+
+				logger.Log("Certificate '%s' is not Ready - '%s'", certificateName, conditionMessage)
+
+				return nil
+			}).
+				WithTimeout(15 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
 		})
 
 		It("hello world app responds successfully", func() {


### PR DESCRIPTION
### What this PR does

Towards: https://github.com/giantswarm/giantswarm/issues/31013

Adds a new test case to the hello-world tests to check that the associated Certificate is created and is ready.

Note: As we're now referencing types from cert-manager in multiple places it doesn't make sense to keep using the `unstructured` type. I won't do it as part of this PR but I plan to update `clustertest` to include the cert-manager schema in the kube client it creates that can then be used in these tests.

Example output:

```
Common tests hello world should have a ready Certificate generated
/Users/marcus/Code/GiantSwarm/cluster-test-suites/internal/common/hello.go:206
  {"level":"info","ts":"2024-06-24T09:32:27+01:00","msg":"Checking for certificate 'hello-world-tls' in namespace 'giantswarm'"}
  {"level":"info","ts":"2024-06-24T09:32:27+01:00","msg":"Found status.condition with type 'Ready' and status 'True' in Certificate 'hello-world-tls'"}
• [0.051 seconds]
```

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
