### PR TITLE
Make use of cert-manager types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use actual types from Cert-Manager instead of using `unstructured` for `Certificate` and `ClusterIssuer`
+
 ## [1.52.0] - 2024-06-25
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.4
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 
 require (
+	github.com/cert-manager/cert-manager v1.15.0
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/giantswarm/cluster-standup-teardown v1.10.0
 	github.com/giantswarm/clustertest v1.6.0
@@ -37,7 +38,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/cert-manager/cert-manager v1.15.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
 	github.com/containerd/containerd v1.7.18 // indirect


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/giantswarm/giantswarm/issues/31130

Switches to using the actual types from Cert-Manager when getting the `ClusterIssuer` and `Certificate` CRs.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
