### PR TITLE
Added test case to check all jobs succeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a test case to check the status of all Jobs in the WC
+
 ## [1.52.0] - 2024-06-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a test case to check the status of all Jobs in the WC
 
+### Changed
+
+- Refactored some functions to explicitly take in a context instance instead of using `context.Background()` so that timeouts set on the context can be respected
+
 ## [1.52.0] - 2024-06-25
 
 ### Changed

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -55,7 +55,7 @@ func runBasic() {
 			wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(wait.Consistent(CheckControlPlaneNodesReady(wcClient, int(replicas)), 12, 5*time.Second)).
+			Eventually(wait.Consistent(CheckControlPlaneNodesReady(state.GetContext(), wcClient, int(replicas)), 12, 5*time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
@@ -69,42 +69,42 @@ func runBasic() {
 			wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(wait.Consistent(CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
+			Eventually(wait.Consistent(CheckWorkerNodesReady(state.GetContext(), wcClient, values), 12, 5*time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
 
 		It("has all its Deployments Ready (means all replicas are running)", func() {
-			Eventually(wait.Consistent(CheckAllDeploymentsReady(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(CheckAllDeploymentsReady(state.GetContext(), wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
 
 		It("has all its StatefulSets Ready (means all replicas are running)", func() {
-			Eventually(wait.Consistent(CheckAllStatefulSetsReady(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(CheckAllStatefulSetsReady(state.GetContext(), wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
 
 		It("has all its DaemonSets Ready (means all daemon pods are running)", func() {
-			Eventually(wait.Consistent(CheckAllDaemonSetsReady(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(CheckAllDaemonSetsReady(state.GetContext(), wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
 
 		It("has all its Jobs completed successfully", func() {
-			Eventually(wait.Consistent(CheckAllJobsSucceeded(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(CheckAllJobsSucceeded(state.GetContext(), wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
 
 		It("has all of its Pods in the Running state", func() {
-			Eventually(wait.Consistent(CheckAllPodsSuccessfulPhase(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(CheckAllPodsSuccessfulPhase(state.GetContext(), wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
@@ -123,13 +123,13 @@ func runBasic() {
 			mcClient := state.GetFramework().MC()
 			cluster := state.GetCluster()
 
-			machinePools, err := state.GetFramework().GetMachinePools(context.Background(), cluster.Name, cluster.GetNamespace())
+			machinePools, err := state.GetFramework().GetMachinePools(state.GetContext(), cluster.Name, cluster.GetNamespace())
 			Expect(err).NotTo(HaveOccurred())
 			if len(machinePools) == 0 {
 				Skip("Machine pools are not found")
 			}
 
-			Eventually(wait.Consistent(CheckMachinePoolsReadyAndRunning(mcClient, cluster.Name, cluster.GetNamespace()), 5, 5*time.Second)).
+			Eventually(wait.Consistent(CheckMachinePoolsReadyAndRunning(state.GetContext(), mcClient, cluster.Name, cluster.GetNamespace()), 5, 5*time.Second)).
 				WithTimeout(30 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
@@ -137,8 +137,8 @@ func runBasic() {
 	})
 }
 
-func CheckControlPlaneNodesReady(wcClient *client.Client, expectedNodes int) func() error {
-	controlPlaneFunc := wait.AreNumNodesReady(context.Background(), wcClient, expectedNodes, &cr.MatchingLabels{"node-role.kubernetes.io/control-plane": ""})
+func CheckControlPlaneNodesReady(ctx context.Context, wcClient *client.Client, expectedNodes int) func() error {
+	controlPlaneFunc := wait.AreNumNodesReady(ctx, wcClient, expectedNodes, &cr.MatchingLabels{"node-role.kubernetes.io/control-plane": ""})
 
 	return func() error {
 		ok, err := controlPlaneFunc()
@@ -149,7 +149,7 @@ func CheckControlPlaneNodesReady(wcClient *client.Client, expectedNodes int) fun
 	}
 }
 
-func CheckWorkerNodesReady(wcClient *client.Client, values *application.ClusterValues) func() error {
+func CheckWorkerNodesReady(ctx context.Context, wcClient *client.Client, values *application.ClusterValues) func() error {
 	minNodes := 0
 	maxNodes := 0
 	for _, pool := range values.NodePools {
@@ -167,7 +167,7 @@ func CheckWorkerNodesReady(wcClient *client.Client, values *application.ClusterV
 		Max: maxNodes,
 	}
 
-	workersFunc := wait.AreNumNodesReadyWithinRange(context.Background(), wcClient, expectedNodes, client.DoesNotHaveLabels{"node-role.kubernetes.io/control-plane"})
+	workersFunc := wait.AreNumNodesReadyWithinRange(ctx, wcClient, expectedNodes, client.DoesNotHaveLabels{"node-role.kubernetes.io/control-plane"})
 
 	return func() error {
 		ok, err := workersFunc()
@@ -182,10 +182,10 @@ func CheckWorkerNodesReady(wcClient *client.Client, values *application.ClusterV
 	}
 }
 
-func CheckAllPodsSuccessfulPhase(wcClient *client.Client) func() error {
+func CheckAllPodsSuccessfulPhase(ctx context.Context, wcClient *client.Client) func() error {
 	return func() error {
 		podList := &corev1.PodList{}
-		err := wcClient.List(context.Background(), podList)
+		err := wcClient.List(ctx, podList)
 		if err != nil {
 			return err
 		}
@@ -203,10 +203,10 @@ func CheckAllPodsSuccessfulPhase(wcClient *client.Client) func() error {
 	}
 }
 
-func CheckAllDeploymentsReady(wcClient *client.Client) func() error {
+func CheckAllDeploymentsReady(ctx context.Context, wcClient *client.Client) func() error {
 	return func() error {
 		deploymentList := &appsv1.DeploymentList{}
-		err := wcClient.List(context.Background(), deploymentList)
+		err := wcClient.List(ctx, deploymentList)
 		if err != nil {
 			return err
 		}
@@ -225,10 +225,10 @@ func CheckAllDeploymentsReady(wcClient *client.Client) func() error {
 	}
 }
 
-func CheckAllStatefulSetsReady(wcClient *client.Client) func() error {
+func CheckAllStatefulSetsReady(ctx context.Context, wcClient *client.Client) func() error {
 	return func() error {
 		statefulSetList := &appsv1.StatefulSetList{}
-		err := wcClient.List(context.Background(), statefulSetList)
+		err := wcClient.List(ctx, statefulSetList)
 		if err != nil {
 			return err
 		}
@@ -247,10 +247,10 @@ func CheckAllStatefulSetsReady(wcClient *client.Client) func() error {
 	}
 }
 
-func CheckAllJobsSucceeded(wcClient *client.Client) func() error {
+func CheckAllJobsSucceeded(ctx context.Context, wcClient *client.Client) func() error {
 	return func() error {
 		jobList := &batchv1.JobList{}
-		err := wcClient.List(context.Background(), jobList)
+		err := wcClient.List(ctx, jobList)
 		if err != nil {
 			return err
 		}
@@ -276,10 +276,10 @@ func CheckAllJobsSucceeded(wcClient *client.Client) func() error {
 	}
 }
 
-func CheckAllDaemonSetsReady(wcClient *client.Client) func() error {
+func CheckAllDaemonSetsReady(ctx context.Context, wcClient *client.Client) func() error {
 	return func() error {
 		daemonSetList := &appsv1.DaemonSetList{}
-		err := wcClient.List(context.Background(), daemonSetList)
+		err := wcClient.List(ctx, daemonSetList)
 		if err != nil {
 			return err
 		}
@@ -300,7 +300,7 @@ func CheckAllDaemonSetsReady(wcClient *client.Client) func() error {
 
 // CheckMachinePoolsReadyAndRunning checks if all MachinePool resources have Ready condition with Status True and are in
 // Running phase.
-func CheckMachinePoolsReadyAndRunning(mcClient *client.Client, clusterName string, clusterNamespace string) func() error {
+func CheckMachinePoolsReadyAndRunning(ctx context.Context, mcClient *client.Client, clusterName string, clusterNamespace string) func() error {
 	return func() error {
 		machinePools := &capiexp.MachinePoolList{}
 		machinePoolListOptions := []cr.ListOption{
@@ -309,7 +309,7 @@ func CheckMachinePoolsReadyAndRunning(mcClient *client.Client, clusterName strin
 				"cluster.x-k8s.io/cluster-name": clusterName,
 			},
 		}
-		err := mcClient.List(context.Background(), machinePools, machinePoolListOptions...)
+		err := mcClient.List(ctx, machinePools, machinePoolListOptions...)
 		if err != nil {
 			return err
 		}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -49,7 +49,7 @@ func Run(cfg *TestConfig) {
 			replicas, err := state.GetFramework().GetExpectedControlPlaneReplicas(state.GetContext(), state.GetCluster().Name, state.GetCluster().GetNamespace())
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(wcClient, int(replicas)), 12, 5*time.Second)).
+			Eventually(wait.Consistent(common.CheckControlPlaneNodesReady(state.GetContext(), wcClient, int(replicas)), 12, 5*time.Second)).
 				WithTimeout(cfg.ControlPlaneNodesTimeout).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
@@ -60,7 +60,7 @@ func Run(cfg *TestConfig) {
 			err := state.GetFramework().MC().GetHelmValues(cluster.Name, cluster.GetNamespace(), values)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(wait.Consistent(common.CheckWorkerNodesReady(wcClient, values), 12, 5*time.Second)).
+			Eventually(wait.Consistent(common.CheckWorkerNodesReady(state.GetContext(), wcClient, values), 12, 5*time.Second)).
 				WithTimeout(cfg.WorkerNodesTimeout).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
@@ -79,13 +79,13 @@ func Run(cfg *TestConfig) {
 			mcClient := state.GetFramework().MC()
 			cluster := state.GetCluster()
 
-			machinePools, err := state.GetFramework().GetMachinePools(context.Background(), cluster.Name, cluster.GetNamespace())
+			machinePools, err := state.GetFramework().GetMachinePools(state.GetContext(), cluster.Name, cluster.GetNamespace())
 			Expect(err).NotTo(HaveOccurred())
 			if len(machinePools) == 0 {
 				Skip("Machine pools are not found")
 			}
 
-			Eventually(wait.Consistent(common.CheckMachinePoolsReadyAndRunning(mcClient, cluster.Name, cluster.GetNamespace()), 5, 5*time.Second)).
+			Eventually(wait.Consistent(common.CheckMachinePoolsReadyAndRunning(state.GetContext(), mcClient, cluster.Name, cluster.GetNamespace()), 5, 5*time.Second)).
 				WithTimeout(30 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
@@ -94,28 +94,28 @@ func Run(cfg *TestConfig) {
 		common.RunApps()
 
 		It("has all its Deployments Ready (means all replicas are running)", func() {
-			Eventually(wait.Consistent(common.CheckAllDeploymentsReady(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(common.CheckAllDeploymentsReady(state.GetContext(), wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
 
 		It("has all its StatefulSets Ready (means all replicas are running)", func() {
-			Eventually(wait.Consistent(common.CheckAllStatefulSetsReady(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(common.CheckAllStatefulSetsReady(state.GetContext(), wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
 
 		It("has all its DaemonSets Ready (means all daemon pods are running)", func() {
-			Eventually(wait.Consistent(common.CheckAllDaemonSetsReady(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(common.CheckAllDaemonSetsReady(state.GetContext(), wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())
 		})
 
 		It("has all of its Pods in the Running state", func() {
-			Eventually(wait.Consistent(common.CheckAllPodsSuccessfulPhase(wcClient), 10, time.Second)).
+			Eventually(wait.Consistent(common.CheckAllPodsSuccessfulPhase(state.GetContext(), wcClient), 10, time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())


### PR DESCRIPTION
### What this PR does

Fixes: https://github.com/giantswarm/giantswarm/issues/31140

Adds a new basic check to ensure all Jobs in the WC have succeded.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
