### PR TITLE
Trigger extra debugging when app tests fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Made use of `GetWarningEventsForResource` from `clustertest` for Cert-Manager tests
+
+### Added
+
+- Use `failurehandler.AppIssues` to provide extra debugging when App-related tests fail (timeout)
+
 ## [1.54.1] - 2024-06-27
 
 ## [1.54.0] - 2024-06-27

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cert-manager/cert-manager v1.15.1
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/giantswarm/cluster-standup-teardown v1.10.0
-	github.com/giantswarm/clustertest v1.8.0
+	github.com/giantswarm/clustertest v1.9.0
 	github.com/gravitational/teleport/api v0.0.0-20240625042611-b3f46c4cd931
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -780,8 +780,8 @@ github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
 github.com/giantswarm/cluster-standup-teardown v1.10.0 h1:0Ka7KI6kgGZ+/efHiJFc+xStnCehm9NbuPp0gw4czyI=
 github.com/giantswarm/cluster-standup-teardown v1.10.0/go.mod h1:3mUvYQR776LcnfX4wDZnHmWVGvznVQ3Ays/z5YVzIeo=
-github.com/giantswarm/clustertest v1.8.0 h1:S9JWUPAssgj9jEAwWgGnUGieAsiyjnN5jaMUEWObfWg=
-github.com/giantswarm/clustertest v1.8.0/go.mod h1:549o+JD/bwCn3hy9+OgswBA6WVA2so58aaKM0Jom2cA=
+github.com/giantswarm/clustertest v1.9.0 h1:1U+nB7B1HYHqwkhIN5lVSaxhydeYmIy9OxwhNdTk0sI=
+github.com/giantswarm/clustertest v1.9.0/go.mod h1:549o+JD/bwCn3hy9+OgswBA6WVA2so58aaKM0Jom2cA=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=
 github.com/giantswarm/k8smetadata v0.25.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.57.0 h1:IMmho55Qq+WE+frJXcTBhx19+J54xwu/j4+pGU5YecA=

--- a/internal/common/apps.go
+++ b/internal/common/apps.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/clustertest/pkg/failurehandler"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/wait"
 
@@ -66,8 +67,11 @@ func RunApps() {
 
 			Eventually(wait.IsAllAppDeployed(state.GetContext(), state.GetFramework().MC(), appNamespacedNames)).
 				WithTimeout(timeout).
-				WithPolling(10 * time.Second).
-				Should(BeTrue())
+				WithPolling(10*time.Second).
+				Should(
+					BeTrue(),
+					failurehandler.AppIssues(state.GetContext(), state.GetFramework(), state.GetCluster()),
+				)
 		})
 	})
 	Context("observability-bundle apps", func() {
@@ -92,9 +96,12 @@ func RunApps() {
 			}
 
 			Eventually(wait.IsAllAppDeployed(state.GetContext(), state.GetFramework().MC(), appNamespacedNames)).
-				WithTimeout(8 * time.Minute).
-				WithPolling(10 * time.Second).
-				Should(BeTrue())
+				WithTimeout(8*time.Minute).
+				WithPolling(10*time.Second).
+				Should(
+					BeTrue(),
+					failurehandler.AppIssues(state.GetContext(), state.GetFramework(), state.GetCluster()),
+				)
 		})
 	})
 	Context("security-bundle apps", func() {
@@ -119,9 +126,12 @@ func RunApps() {
 			}
 
 			Eventually(wait.IsAllAppDeployed(state.GetContext(), state.GetFramework().MC(), appNamespacedNames)).
-				WithTimeout(10 * time.Minute).
-				WithPolling(10 * time.Second).
-				Should(BeTrue())
+				WithTimeout(10*time.Minute).
+				WithPolling(10*time.Second).
+				Should(
+					BeTrue(),
+					failurehandler.AppIssues(state.GetContext(), state.GetFramework(), state.GetCluster()),
+				)
 		})
 	})
 }


### PR DESCRIPTION
### What this PR does

* Updated to latest `clustertest`
* Changed cert-manager tests to make use of Event helpers from `clustertest` (closes https://github.com/giantswarm/giantswarm/issues/31142)
* Trigger extra debugging to be logged when App-related tests fail with timeout. (Towards https://github.com/giantswarm/giantswarm/issues/31013)

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
