### PR TITLE
Support Release upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated upgrade tests so they can test upgrades to Releases
+
 ## [1.55.0] - 2024-06-28
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 require (
 	github.com/cert-manager/cert-manager v1.15.1
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/cluster-standup-teardown v1.10.0
-	github.com/giantswarm/clustertest v1.9.0
+	github.com/giantswarm/cluster-standup-teardown v1.11.0
+	github.com/giantswarm/clustertest v1.10.0
 	github.com/gravitational/teleport/api v0.0.0-20240628180307-921884f4cd33
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -778,10 +778,10 @@ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyT
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/cluster-standup-teardown v1.10.0 h1:0Ka7KI6kgGZ+/efHiJFc+xStnCehm9NbuPp0gw4czyI=
-github.com/giantswarm/cluster-standup-teardown v1.10.0/go.mod h1:3mUvYQR776LcnfX4wDZnHmWVGvznVQ3Ays/z5YVzIeo=
-github.com/giantswarm/clustertest v1.9.0 h1:1U+nB7B1HYHqwkhIN5lVSaxhydeYmIy9OxwhNdTk0sI=
-github.com/giantswarm/clustertest v1.9.0/go.mod h1:549o+JD/bwCn3hy9+OgswBA6WVA2so58aaKM0Jom2cA=
+github.com/giantswarm/cluster-standup-teardown v1.11.0 h1:rNH+sMBL1seUW71YK7T83xu5QwwKfMZnGUOp6gbSI4s=
+github.com/giantswarm/cluster-standup-teardown v1.11.0/go.mod h1:sZfoCgBz34x3WzQOKpT0CLKrbicHA/DkUznWr+LObqI=
+github.com/giantswarm/clustertest v1.10.0 h1:npJARVngBhqP+XtKEsPUCSvwRDmQfkOAVFwAMRTpD/U=
+github.com/giantswarm/clustertest v1.10.0/go.mod h1:549o+JD/bwCn3hy9+OgswBA6WVA2so58aaKM0Jom2cA=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=
 github.com/giantswarm/k8smetadata v0.25.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.57.0 h1:IMmho55Qq+WE+frJXcTBhx19+J54xwu/j4+pGU5YecA=

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -122,8 +122,11 @@ func Run(cfg *TestConfig) {
 		})
 
 		It("should apply new version successfully", func() {
-			// Set app versions to `""` so that it makes use of the overrides set in the `E2E_OVERRIDE_VERSIONS` environment var
-			cluster = cluster.WithAppVersions("", "")
+			cluster = cluster.
+				// Set app versions to `""` so that it makes use of the overrides set in the `E2E_OVERRIDE_VERSIONS` environment var
+				WithAppVersions("", "").
+				// Set release versions to `""` so that it makes use of the overrides set in the `E2E_RELEASE_VERSION` environment var
+				WithRelease(application.ReleasePair{Version: "", Commit: ""})
 			applyCtx, cancelApplyCtx := context.WithTimeout(state.GetContext(), 20*time.Minute)
 			defer cancelApplyCtx()
 


### PR DESCRIPTION
### What this PR does

Towards: https://github.com/giantswarm/roadmap/issues/3537

Upgrades `clustertest` and `cluster-standup-teardown` with support for Release upgrades and modifies the upgrade test to ensure the cluster upgrade performs an upgrade to the release.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
