### PR TITLE
Fix upgrade tests for Releases test pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow upgrade tests to be run from Releases test pipeline
+
 ## [1.57.0] - 2024-07-05
 
 ### Changed

--- a/internal/helper/upgrade.go
+++ b/internal/helper/upgrade.go
@@ -1,0 +1,20 @@
+package helper
+
+import (
+	"os"
+	"strings"
+
+	"github.com/giantswarm/clustertest/pkg/env"
+)
+
+// ShouldSkipUpgrade checks for the required environment variables needed to run the upgrade test suite
+func ShouldSkipUpgrade() bool {
+	overrideVersions := strings.TrimSpace(os.Getenv(env.OverrideVersions))
+	releaseVersion := strings.TrimSpace(os.Getenv(env.ReleaseVersion))
+
+	if overrideVersions == "" && releaseVersion == "" {
+		return true
+	}
+
+	return false
+}

--- a/internal/suite/setup.go
+++ b/internal/suite/setup.go
@@ -2,8 +2,6 @@ package suite
 
 import (
 	"context"
-	"os"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,6 +13,7 @@ import (
 	"github.com/giantswarm/clustertest/pkg/client"
 	"github.com/giantswarm/clustertest/pkg/logger"
 
+	"github.com/giantswarm/cluster-test-suites/internal/helper"
 	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
 
@@ -23,7 +22,7 @@ import (
 // be checked for at least a single control plane node being marked as ready.
 func Setup(isUpgrade bool, clusterBuilder cb.ClusterBuilder, clusterReadyFns ...func(client *client.Client)) {
 	BeforeSuite(func() {
-		if isUpgrade && strings.TrimSpace(os.Getenv("E2E_OVERRIDE_VERSIONS")) == "" {
+		if isUpgrade && helper.ShouldSkipUpgrade() {
 			Skip("E2E_OVERRIDE_VERSIONS env var not set, skipping upgrade test")
 			return
 		}
@@ -45,7 +44,7 @@ func Setup(isUpgrade bool, clusterBuilder cb.ClusterBuilder, clusterReadyFns ...
 	})
 
 	AfterSuite(func() {
-		if isUpgrade && strings.TrimSpace(os.Getenv("E2E_OVERRIDE_VERSIONS")) == "" {
+		if isUpgrade && helper.ShouldSkipUpgrade() {
 			return
 		}
 


### PR DESCRIPTION
### What this PR does

Fix the upgrade suite skip check to allow running when testing against releases instead of just specific app versions.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

Note: Skipping E2E tests as upgrade tests aren't able to be tested from this repo. 
