### PR TITLE
Added failure handling for not having expected number of ready replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added failure handling for Deployment, StatefulSet and DaemonSet not having expected number of ready replicas
+
 ## [1.57.2] - 2024-07-05
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cert-manager/cert-manager v1.15.1
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/giantswarm/cluster-standup-teardown v1.12.1
-	github.com/giantswarm/clustertest v1.12.0
+	github.com/giantswarm/clustertest v1.13.0
 	github.com/gravitational/teleport/api v0.0.0-20240705235643-4257daa0c447
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -782,8 +782,8 @@ github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
 github.com/giantswarm/cluster-standup-teardown v1.12.1 h1:kSnd3SJACLgbVmTPbh1zuN+1BtsH4KMlm1vn6RB5r38=
 github.com/giantswarm/cluster-standup-teardown v1.12.1/go.mod h1:yTGCDE+018kFVKtSGE2W/oYphaxg0+6stkYv/seSg2k=
-github.com/giantswarm/clustertest v1.12.0 h1:ldXNCe+53tZ6LoHbm9p9rlaizRya2pxxVT8DnIepTUo=
-github.com/giantswarm/clustertest v1.12.0/go.mod h1:6MxraDlEKj0X95o8NH/bFRk1tvYO4xwV6WvWm/GUrYk=
+github.com/giantswarm/clustertest v1.13.0 h1:idKC+ugZJbW03OCxWZS1njLNvcrF2TCZMIskCl9eWqs=
+github.com/giantswarm/clustertest v1.13.0/go.mod h1:6MxraDlEKj0X95o8NH/bFRk1tvYO4xwV6WvWm/GUrYk=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=
 github.com/giantswarm/k8smetadata v0.25.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.57.0 h1:IMmho55Qq+WE+frJXcTBhx19+J54xwu/j4+pGU5YecA=

--- a/internal/common/apps.go
+++ b/internal/common/apps.go
@@ -70,7 +70,7 @@ func RunApps() {
 				WithPolling(10*time.Second).
 				Should(
 					BeTrue(),
-					failurehandler.AppIssues(state.GetContext(), state.GetFramework(), state.GetCluster()),
+					failurehandler.AppIssues(state.GetFramework(), state.GetCluster()),
 				)
 		})
 	})
@@ -100,7 +100,7 @@ func RunApps() {
 				WithPolling(10*time.Second).
 				Should(
 					BeTrue(),
-					failurehandler.AppIssues(state.GetContext(), state.GetFramework(), state.GetCluster()),
+					failurehandler.AppIssues(state.GetFramework(), state.GetCluster()),
 				)
 		})
 	})
@@ -130,7 +130,7 @@ func RunApps() {
 				WithPolling(10*time.Second).
 				Should(
 					BeTrue(),
-					failurehandler.AppIssues(state.GetContext(), state.GetFramework(), state.GetCluster()),
+					failurehandler.AppIssues(state.GetFramework(), state.GetCluster()),
 				)
 		})
 	})

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -15,6 +15,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/state"
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/client"
+	"github.com/giantswarm/clustertest/pkg/failurehandler"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/wait"
 
@@ -77,23 +78,32 @@ func runBasic() {
 
 		It("has all its Deployments Ready (means all replicas are running)", func() {
 			Eventually(wait.Consistent(CheckAllDeploymentsReady(state.GetContext(), wcClient), 10, time.Second)).
-				WithTimeout(15 * time.Minute).
+				WithTimeout(15*time.Minute).
 				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
+				Should(
+					Succeed(),
+					failurehandler.DeploymentsNotReady(state.GetFramework(), state.GetCluster()),
+				)
 		})
 
 		It("has all its StatefulSets Ready (means all replicas are running)", func() {
 			Eventually(wait.Consistent(CheckAllStatefulSetsReady(state.GetContext(), wcClient), 10, time.Second)).
-				WithTimeout(15 * time.Minute).
+				WithTimeout(15*time.Minute).
 				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
+				Should(
+					Succeed(),
+					failurehandler.StatefulSetsNotReady(state.GetFramework(), state.GetCluster()),
+				)
 		})
 
 		It("has all its DaemonSets Ready (means all daemon pods are running)", func() {
 			Eventually(wait.Consistent(CheckAllDaemonSetsReady(state.GetContext(), wcClient), 10, time.Second)).
-				WithTimeout(15 * time.Minute).
+				WithTimeout(15*time.Minute).
 				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
+				Should(
+					Succeed(),
+					failurehandler.DaemonSetsNotReady(state.GetFramework(), state.GetCluster()),
+				)
 		})
 
 		It("has all its Jobs completed successfully", func() {


### PR DESCRIPTION
### What this PR does

Towards: https://github.com/giantswarm/giantswarm/issues/31013

Makes use of new failure handlers to add extra debug information when Deployments, DaemonSets or StatefulSets fail to become ready before the test timeout.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
