### PR TITLE
Update clustertest to include logs when debugging pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added failure handling for Deployment, StatefulSet and DaemonSet not having expected number of ready replicas
+- Updated `clustertest` to include logs when debugging failing pods
 
 ## [1.57.2] - 2024-07-05
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cert-manager/cert-manager v1.15.1
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/giantswarm/cluster-standup-teardown v1.12.1
-	github.com/giantswarm/clustertest v1.13.0
+	github.com/giantswarm/clustertest v1.14.0
 	github.com/gravitational/teleport/api v0.0.0-20240705235643-4257daa0c447
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -782,8 +782,8 @@ github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
 github.com/giantswarm/cluster-standup-teardown v1.12.1 h1:kSnd3SJACLgbVmTPbh1zuN+1BtsH4KMlm1vn6RB5r38=
 github.com/giantswarm/cluster-standup-teardown v1.12.1/go.mod h1:yTGCDE+018kFVKtSGE2W/oYphaxg0+6stkYv/seSg2k=
-github.com/giantswarm/clustertest v1.13.0 h1:idKC+ugZJbW03OCxWZS1njLNvcrF2TCZMIskCl9eWqs=
-github.com/giantswarm/clustertest v1.13.0/go.mod h1:6MxraDlEKj0X95o8NH/bFRk1tvYO4xwV6WvWm/GUrYk=
+github.com/giantswarm/clustertest v1.14.0 h1:Ecx17jwrKVbiB2djb8vL9SBPRboWbl1gAHDiz7c5n+8=
+github.com/giantswarm/clustertest v1.14.0/go.mod h1:6MxraDlEKj0X95o8NH/bFRk1tvYO4xwV6WvWm/GUrYk=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=
 github.com/giantswarm/k8smetadata v0.25.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.57.0 h1:IMmho55Qq+WE+frJXcTBhx19+J54xwu/j4+pGU5YecA=


### PR DESCRIPTION
### What this PR does

Include log output when debugging failing pods

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
