### PR TITLE
updated cluster-standup-teardown to the latest release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `cluster-standup-teardown` to the latest release.
+
 ## [1.58.0] - 2024-07-08
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 require (
 	github.com/cert-manager/cert-manager v1.15.1
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/cluster-standup-teardown v1.12.1
+	github.com/giantswarm/cluster-standup-teardown v1.13.0
 	github.com/giantswarm/clustertest v1.14.0
 	github.com/gravitational/teleport/api v0.0.0-20240705235643-4257daa0c447
 	github.com/onsi/ginkgo/v2 v2.19.0

--- a/go.sum
+++ b/go.sum
@@ -780,8 +780,8 @@ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyT
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/cluster-standup-teardown v1.12.1 h1:kSnd3SJACLgbVmTPbh1zuN+1BtsH4KMlm1vn6RB5r38=
-github.com/giantswarm/cluster-standup-teardown v1.12.1/go.mod h1:yTGCDE+018kFVKtSGE2W/oYphaxg0+6stkYv/seSg2k=
+github.com/giantswarm/cluster-standup-teardown v1.13.0 h1:k1gcwBI4OBOdYo6gQsTiG6zCHe7FrVPOSMkyaY2eJfM=
+github.com/giantswarm/cluster-standup-teardown v1.13.0/go.mod h1:yTGCDE+018kFVKtSGE2W/oYphaxg0+6stkYv/seSg2k=
 github.com/giantswarm/clustertest v1.14.0 h1:Ecx17jwrKVbiB2djb8vL9SBPRboWbl1gAHDiz7c5n+8=
 github.com/giantswarm/clustertest v1.14.0/go.mod h1:6MxraDlEKj0X95o8NH/bFRk1tvYO4xwV6WvWm/GUrYk=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=


### PR DESCRIPTION
### What this PR does

bumps `cluster-standup-teardown` to the latest release

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Notes

I'm skipping the e2e tests for now as this only affects CAPV. I'm testing those under [this pr](https://github.com/giantswarm/cluster-vsphere/pull/232)
