### PR TITLE
Added framework for overriding test timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A framework for overriding default timeouts used by test cases. Introduces a new `timeout` internal package and new functions on the `state` that allows getting and setting a custom timeout per test suite.
+
 ## [1.59.0] - 2024-07-09
 
 ### Changed

--- a/internal/common/apps.go
+++ b/internal/common/apps.go
@@ -15,11 +15,7 @@ import (
 	"github.com/giantswarm/clustertest/pkg/wait"
 
 	"github.com/giantswarm/cluster-test-suites/internal/state"
-)
-
-const (
-	DeployAppsTimeoutContextKey = "deployAppsTimeout"
-	DefaultDeployAppsTimeout    = 15 * time.Minute
+	"github.com/giantswarm/cluster-test-suites/internal/timeout"
 )
 
 func RunApps() {
@@ -28,7 +24,7 @@ func RunApps() {
 			skipDefaultAppsApp, err := state.GetCluster().UsesUnifiedClusterApp()
 			Expect(err).NotTo(HaveOccurred())
 
-			timeout := getTimeoutFromContext()
+			timeout := state.GetTestTimeout(timeout.DeployApps, 15*time.Minute)
 			logger.Log("Waiting for all apps to be deployed. Timeout: %s", timeout.String())
 
 			// We need to wait for default-apps to be deployed before we can check all apps.
@@ -134,17 +130,4 @@ func RunApps() {
 				)
 		})
 	})
-}
-
-// getTimeoutFromContext returns the timeout for deploying apps from the context.
-// If the timeout is not set, it returns the default value
-func getTimeoutFromContext() time.Duration {
-	var timeout time.Duration
-	t := state.GetContext().Value(DeployAppsTimeoutContextKey)
-	if t != nil {
-		timeout = t.(time.Duration)
-	} else {
-		timeout = DefaultDeployAppsTimeout
-	}
-	return timeout
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -3,6 +3,9 @@ package state
 import (
 	"context"
 	"sync"
+	"time"
+
+	"github.com/giantswarm/cluster-test-suites/internal/timeout"
 
 	"github.com/giantswarm/clustertest"
 	"github.com/giantswarm/clustertest/pkg/application"
@@ -55,4 +58,22 @@ func SetCluster(framework *application.Cluster) {
 
 func GetCluster() *application.Cluster {
 	return get().cluster
+}
+
+// SetTestTImeout sets the provided timeout against the given TestKey in the current state context to be used by tests
+func SetTestTimeout(testKey timeout.TestKey, timeout time.Duration) {
+	s := get()
+	ctx := context.WithValue(s.ctx, testKey, timeout)
+	SetContext(ctx)
+}
+
+// GetTestTimeout returns the timeout from the context for the given TestKey or the defaultTimeout if not found
+func GetTestTimeout(testKey timeout.TestKey, defaultTimeout time.Duration) time.Duration {
+	s := get()
+	val, ok := s.ctx.Value(testKey).(time.Duration)
+	if ok {
+		return val
+	}
+
+	return defaultTimeout
 }

--- a/internal/timeout/consts.go
+++ b/internal/timeout/consts.go
@@ -1,0 +1,6 @@
+package timeout
+
+const (
+	// DeployApps is used by "all default apps are deployed without issues"
+	DeployApps TestKey = "deployAppsTimeout"
+)

--- a/internal/timeout/doc.go
+++ b/internal/timeout/doc.go
@@ -1,0 +1,11 @@
+// package timeout contains types and constants to be used when overriding default test timeouts
+//
+// Each test case that supports overriding the timeout it uses by default will need its own `TestKey` defining
+// in the constants. Once this is available it can be used within the test case like the following:
+//
+//	timeout := state.GetTestTimeout(timeout.DeployApps, 15*time.Minute)
+//
+// To then override the timeout in a specific test sutie you can do so like this following:
+//
+//	state.SetTestTimeout(timeout.DeployApps, time.Minute*25)
+package timeout

--- a/internal/timeout/type.go
+++ b/internal/timeout/type.go
@@ -1,0 +1,4 @@
+package timeout
+
+// TestKey is a unique name used to identify the timeout to use with a specific test
+type TestKey string

--- a/providers/capa/china/capa_test.go
+++ b/providers/capa/china/capa_test.go
@@ -1,18 +1,19 @@
 package china
 
 import (
-	"context"
-	. "github.com/onsi/ginkgo/v2"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
 
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 	"github.com/giantswarm/cluster-test-suites/internal/state"
+	"github.com/giantswarm/cluster-test-suites/internal/timeout"
 )
 
 var _ = Describe("Common tests", func() {
 	BeforeEach(func() {
 		// Set the timeout for deploying apps to 25 minutes for China test
-		state.SetContext(context.WithValue(state.GetContext(), common.DeployAppsTimeoutContextKey, time.Minute*25))
+		state.SetTestTimeout(timeout.DeployApps, time.Minute*25)
 	})
 
 	common.Run(&common.TestConfig{


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/giantswarm/giantswarm/issues/31064

Introduces a way to set and get timeouts for specific test cases per test suite.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
