### PR TITLE
update cluster-standup-teardown to v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A framework for overriding default timeouts used by test cases. Introduces a new `timeout` internal package and new functions on the `state` that allows getting and setting a custom timeout per test suite.
 
+### Changed
+
+- Update `cluster-standup-teardown` to `v0.15.0`
+
 ## [1.59.0] - 2024-07-09
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 require (
 	github.com/cert-manager/cert-manager v1.15.1
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/cluster-standup-teardown v1.14.0
+	github.com/giantswarm/cluster-standup-teardown v1.15.0
 	github.com/giantswarm/clustertest v1.15.0
 	github.com/gravitational/teleport/api v0.0.0-20240720001016-ecfa26a68e14
 	github.com/onsi/ginkgo/v2 v2.19.0

--- a/go.sum
+++ b/go.sum
@@ -780,8 +780,8 @@ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyT
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/cluster-standup-teardown v1.14.0 h1:5bOkkV21U477u04wCEdn0/R0WCYmTHSnGCF4911hq9A=
-github.com/giantswarm/cluster-standup-teardown v1.14.0/go.mod h1:yTGCDE+018kFVKtSGE2W/oYphaxg0+6stkYv/seSg2k=
+github.com/giantswarm/cluster-standup-teardown v1.15.0 h1:9dS6vMTh2G44dHiD3fVv2OuqK+lpa2otlXuOh8rTzVs=
+github.com/giantswarm/cluster-standup-teardown v1.15.0/go.mod h1:qiO55mS41UpLWvTeOGjRWN0MLJm8wW8+XKpB70zKb3k=
 github.com/giantswarm/clustertest v1.15.0 h1:qmmR48wg1c+SuYoWBefHUZBcDjdkfkXGypG0uMCiBjI=
 github.com/giantswarm/clustertest v1.15.0/go.mod h1:wq6D/sEqIrsD9Nlrwk1YSuCiqrfO8Ah3AQ4DQJ4lEl8=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=


### PR DESCRIPTION
### What this PR does


### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
