### PR TITLE
Bump clustertest and cluster-standup-teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `clustertest` and `cluster-standup-teardown` to support Releases with CAPZ
+
 ## [1.60.0] - 2024-07-22
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 require (
 	github.com/cert-manager/cert-manager v1.15.1
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/cluster-standup-teardown v1.16.0
-	github.com/giantswarm/clustertest v1.15.0
+	github.com/giantswarm/cluster-standup-teardown v1.17.0
+	github.com/giantswarm/clustertest v1.16.0
 	github.com/gravitational/teleport/api v0.0.0-20240720001016-ecfa26a68e14
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
@@ -65,7 +65,7 @@ require (
 	github.com/giantswarm/microerror v0.4.1 // indirect
 	github.com/giantswarm/organization-operator v1.6.3 // indirect
 	github.com/giantswarm/release-operator/v4 v4.2.0 // indirect
-	github.com/giantswarm/releases/sdk v0.4.0 // indirect
+	github.com/giantswarm/releases/sdk v0.5.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -780,10 +780,10 @@ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyT
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/cluster-standup-teardown v1.16.0 h1:pvIYmV/wztniHVGTQwgky/RoHj1QRhJejGPeoEvzSxA=
-github.com/giantswarm/cluster-standup-teardown v1.16.0/go.mod h1:x8PNI3TY01IbzJyKmbFf+EeS9Y+mfZl9JuXE0kNP/nM=
-github.com/giantswarm/clustertest v1.15.0 h1:qmmR48wg1c+SuYoWBefHUZBcDjdkfkXGypG0uMCiBjI=
-github.com/giantswarm/clustertest v1.15.0/go.mod h1:wq6D/sEqIrsD9Nlrwk1YSuCiqrfO8Ah3AQ4DQJ4lEl8=
+github.com/giantswarm/cluster-standup-teardown v1.17.0 h1:OAmKTBGForNnHZdw9ckjnL/Noq4lE5Yv1tq0QCLNaD4=
+github.com/giantswarm/cluster-standup-teardown v1.17.0/go.mod h1:XOpixpaiHkqGaVMhnKphJiVF9RXOZN/IvsxTL28/MlY=
+github.com/giantswarm/clustertest v1.16.0 h1:YcKnHTU/dBreYEtpIrGvr5PdQx8ywblXakBzYoHs1Kg=
+github.com/giantswarm/clustertest v1.16.0/go.mod h1:WQOv0fivZSM7A1C5GP6tAK+smUU7Z+fan8PDzbag4Dw=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=
 github.com/giantswarm/k8smetadata v0.25.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.57.0 h1:IMmho55Qq+WE+frJXcTBhx19+J54xwu/j4+pGU5YecA=
@@ -794,8 +794,8 @@ github.com/giantswarm/organization-operator v1.6.3 h1:hwfszk6pm6omT3bzJiD8+h4v5G
 github.com/giantswarm/organization-operator v1.6.3/go.mod h1:wtchBVnf4aOrZb/1pZO8szfrRPXsZbbyovfQRZPaIEo=
 github.com/giantswarm/release-operator/v4 v4.2.0 h1:8aU8V3BlF/sKmYG1MgcPGXs8Q/cOlZfhgK4/oBfMPbg=
 github.com/giantswarm/release-operator/v4 v4.2.0/go.mod h1:/ew0vh4BnfJqOddNTcm7iAHvm7g4MBp5C+pxi+H4ydk=
-github.com/giantswarm/releases/sdk v0.4.0 h1:wua8bYGtQktXkEPQJgZFUrivpev1yaV6DwNF08OmiwE=
-github.com/giantswarm/releases/sdk v0.4.0/go.mod h1:EVc38EK1t7VsZPZnFFER1haLMkk7qBC6H0o8bOWWkak=
+github.com/giantswarm/releases/sdk v0.5.0 h1:tmCzXT4DkZ8QdxuVXzNycf1pdH1ImbshbVYqXaCN2mw=
+github.com/giantswarm/releases/sdk v0.5.0/go.mod h1:EVc38EK1t7VsZPZnFFER1haLMkk7qBC6H0o8bOWWkak=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=


### PR DESCRIPTION
### What this PR does

Update deps so CAPZ uses releases

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
