### PR TITLE
Skip rolling update control plane tests if the control plane resource did not change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Skip rolling update control plane tests if the control plane resource did not change
+
 ## [1.62.1] - 2024-07-26
 
 ### Fixed


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3451

### What this PR does

Skips the control plane rolling upgrade tests if the resource generation did not change (the control plane config didn't change and no rolling update is necessary).

Tested with local runs of the capa upgrade.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/run cluster-test-suites
