### PR TITLE
Update the codeowners for the repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,12 @@
 # Main / Shared
 * @giantswarm/team-tinkerers
-/common @giantswarm/team-phoenix @giantswarm/team-rocket
+/internal @giantswarm/team-phoenix @giantswarm/team-rocket
+/internal/teleport @giantswarm/team-bigmac
 
 # Teams:
 /providers/capz @giantswarm/team-phoenix
 /providers/capa @giantswarm/team-phoenix
+/providers/eks @giantswarm/team-phoenix
 /providers/capvcd @giantswarm/team-rocket
 /providers/capv @giantswarm/team-rocket
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Main / Shared
 * @giantswarm/team-tinkerers
-/internal @giantswarm/team-phoenix @giantswarm/team-rocket
+/internal @giantswarm/team-phoenix @giantswarm/team-rocket @giantswarm/team-turtles
 /internal/teleport @giantswarm/team-bigmac
 
 # Teams:


### PR DESCRIPTION
### What this PR does

I noticed that the codeowners were incorrect after a refactor from quite a while ago 😅 

* Changed `common` to `internal` as it now is called
* Added EKS provider with Team Phoenix
* Added Team Bigmac of the owners of the teleport internal module

### Checklist

N/A

### Trigger e2e tests

N/A