### PR TITLE
Log cluster App status on failure to standup cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Output some debug logging when Cluster fails to standup during `BeforeSuite`
+
 ## [1.66.0] - 2024-08-22
 
 ### Added

--- a/internal/suite/setup.go
+++ b/internal/suite/setup.go
@@ -38,9 +38,55 @@ func Setup(isUpgrade bool, clusterBuilder cb.ClusterBuilder, clusterReadyFns ...
 		cluster := cb.LoadOrBuildCluster(framework, clusterBuilder)
 		state.SetCluster(cluster)
 
+		// We'll use this to track if the BeforeSuite failed and if we should do extra debug logging
+		setupComplete := false
+		defer (func() {
+			if !setupComplete {
+				// If we fail to standup the cluster, lets grab the status of the cluster App to see if there's an error
+				ctx := context.Background()
+				ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+				defer cancel()
+
+				cluster := state.GetCluster()
+
+				logger.Log("Attempting to get debug info for Cluster App")
+
+				clusterApp, err := framework.GetApp(ctx, cluster.ClusterApp.InstallName, cluster.ClusterApp.GetNamespace())
+				if err != nil {
+					logger.Log("Failed to get Cluster App: %v", err)
+					return
+				}
+
+				logger.Log(
+					"Cluster App status: AppVersion='%s', Version='%s', ReleaseStatus='%s', ReleaseReason='%s', LastDeployed='%v'",
+					clusterApp.Status.AppVersion,
+					clusterApp.Status.Version,
+					clusterApp.Status.Release.Status,
+					clusterApp.Status.Release.Reason,
+					clusterApp.Status.Release.LastDeployed,
+				)
+
+				logger.Log("Getting events for the Cluster App")
+				events, err := framework.MC().GetEventsForResource(ctx, clusterApp)
+				if err != nil {
+					logger.Log("Failed to get events for App: %v", err)
+					return
+				}
+				if len(events.Items) == 0 {
+					logger.Log("No events found for Cluster App")
+				}
+				for _, event := range events.Items {
+					logger.Log("Event: Reason='%s', Message='%s', Last Occurred='%v'", event.Reason, event.Message, event.LastTimestamp)
+				}
+			}
+		})()
+
 		cluster, err = standup.New(framework, isUpgrade, clusterReadyFns...).Standup(cluster)
 		Expect(err).NotTo(HaveOccurred())
 		state.SetCluster(cluster)
+
+		// Make sure this comes last
+		setupComplete = true
 	})
 
 	AfterSuite(func() {


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/giantswarm/roadmap/issues/3641

If the `BeforeSuite` fails we will attempt to grab the status of the cluster App to see if there has been any deployment errors.

Example:

```
{"level":"info","ts":"2024-08-22T13:55:13+01:00","msg":"Cluster App status: AppVersion='', Version='2.0.0-d7a8852053bca7655bf783c6e820cc85cdc4cc32', ReleaseStatus='deployed', ReleaseReason='', LastDeployed='2024-08-22 13:39:13 +0100 BST'"}
```

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
