### PR TITLE
update standup-teardown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/alessio/shellescape => al.essio.dev/pkg/shellescape v1.4.2
 require (
 	github.com/cert-manager/cert-manager v1.15.3
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/cluster-standup-teardown v1.25.1
+	github.com/giantswarm/cluster-standup-teardown v1.25.2
 	github.com/giantswarm/clustertest v1.25.0
 	github.com/gravitational/teleport/api v0.0.0-20240921192342-ed26cb119227
 	github.com/onsi/ginkgo/v2 v2.20.2

--- a/go.sum
+++ b/go.sum
@@ -784,8 +784,8 @@ github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXE
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/cluster-standup-teardown v1.25.1 h1:PgQG3qhzbo5ZFMEbVtRJRCRnTQjnobteQ+RjlUCL4qU=
-github.com/giantswarm/cluster-standup-teardown v1.25.1/go.mod h1:0BotQzc3cyOfzfm7UueCHxTgqkC7y2WnPy/PpaeRlNQ=
+github.com/giantswarm/cluster-standup-teardown v1.25.2 h1:5J93c/NH5n3sKbL6xQy/y3C/9RlRqiEPWbVq28cORmY=
+github.com/giantswarm/cluster-standup-teardown v1.25.2/go.mod h1:5KKGBU7buz1/vdFQrv4xm6UBfO4DTX9jRuyf3RF3qzo=
 github.com/giantswarm/clustertest v1.25.0 h1:6ud914M4Gz4VFh1cgU66z5GUKjdaO6yr5QgK3VgWDJo=
 github.com/giantswarm/clustertest v1.25.0/go.mod h1:4KTaLaXrIxN4qmgXrWLf6iydqWre/ZgkJoh29qukRlI=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=


### PR DESCRIPTION
### What this PR does
towards https://github.com/giantswarm/giantswarm/issues/31193
This fixes the tests for the newest capvcd release

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
