### PR TITLE
Added private ECR tests to CAPA test suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added test to CAPA test suites to test pulling private images from ECR
+
 ## [1.71.2] - 2024-09-26
 
 ### Changed
@@ -17,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgraded `cluster-standup-teardown` to remove node classes from capvcd test values 
+- Upgraded `cluster-standup-teardown` to remove node classes from capvcd test values
 
 ## [1.71.0] - 2024-09-23
 

--- a/internal/ecr/assets.go
+++ b/internal/ecr/assets.go
@@ -1,0 +1,46 @@
+package ecr
+
+var deploymentManifest = []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alpine
+  namespace: default
+  labels:
+    app: ecr-private-pull-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ecr-private-pull-test
+  template:
+    metadata:
+      labels:
+        app: ecr-private-pull-test
+    spec:
+      containers:
+      - name: alpine-container
+        image: 992382781567.dkr.ecr.eu-west-2.amazonaws.com/giantswarm/alpine:latest
+        command: ["/bin/sh", "-c"]
+        args:
+          - date && sleep 300
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 3000
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+        resources:
+          limits:
+            cpu: "100m"
+            memory: "128Mi"
+          requests:
+            cpu: "50m"
+            memory: "64Mi"
+`)

--- a/internal/ecr/ecr.go
+++ b/internal/ecr/ecr.go
@@ -1,0 +1,98 @@
+package ecr
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/clustertest/pkg/client"
+	"github.com/giantswarm/clustertest/pkg/logger"
+	"github.com/giantswarm/clustertest/pkg/wait"
+	appsv1 "k8s.io/api/apps/v1"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/cluster-test-suites/internal/helper"
+	"github.com/giantswarm/cluster-test-suites/internal/state"
+)
+
+func Run() {
+
+	/*
+		Note: These tests use a pre-created private ECR repository - 992382781567.dkr.ecr.eu-west-2.amazonaws.com/giantswarm/alpine
+		This repository exists in an account controlled by us and has permissions set to allow any AWS account within the
+		Giant Swarm AWS Organisation to be able to pull from it (based on `aws:ResourceOrgID`).
+
+		The image being used is the latest (at time of creation) upstream `alpine` image with no changes.
+
+		The test only uses it to check that the image can be pulled without hitting an unauthorized error.
+	*/
+
+	Context("ecr credential provider", func() {
+		var wcClient *client.Client
+
+		BeforeEach(func() {
+			var err error
+
+			wcClient, err = state.GetFramework().WC(state.GetCluster().Name)
+			if err != nil {
+				Fail(err.Error())
+			}
+		})
+
+		It("should be able to pull an image from a private ECR registry", func() {
+			deploymentObj, err := helper.Deserialize(deploymentManifest)
+			Expect(err).ToNot(HaveOccurred())
+			deployment := deploymentObj.(*appsv1.Deployment)
+
+			Eventually(func() error {
+				logger.Log("Creating deployment with private ECR image...")
+				err = wcClient.Create(state.GetContext(), deployment)
+				if err != nil && !apierror.IsAlreadyExists(err) {
+					return err
+				}
+
+				return nil
+			}).
+				WithTimeout(1 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+
+			Eventually(func() error {
+				logger.Log("Checking status of deployments replicas...")
+				err := wcClient.Get(context.Background(), cr.ObjectKey{Name: deployment.ObjectMeta.Name, Namespace: deployment.ObjectMeta.Namespace}, deployment)
+				if err != nil {
+					return err
+				}
+
+				if deployment.Status.ReadyReplicas != deployment.Status.Replicas {
+					logger.Log("Deployment isn't yet ready %d/%d pod replicas ready", deployment.Status.ReadyReplicas, deployment.Status.Replicas)
+					return fmt.Errorf("deployment %s in namespace %s doesn't have all replicas ready", deployment.ObjectMeta.Name, deployment.ObjectMeta.Namespace)
+				}
+
+				if deployment.Status.Replicas == 0 {
+					logger.Log("Deployment isn't yet ready - it currently has no replicas")
+					return fmt.Errorf("deployment %s in namespace %s has no replicas", deployment.ObjectMeta.Name, deployment.ObjectMeta.Namespace)
+				}
+
+				logger.Log("Deployment has %d ready pod replicas", deployment.Status.ReadyReplicas)
+
+				return nil
+			}).
+				WithTimeout(2 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+
+			Eventually(func() error {
+				logger.Log("Deleting deployment...")
+				return wcClient.Delete(state.GetContext(), deployment)
+			}).
+				WithTimeout(1 * time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(Succeed())
+		})
+	})
+}

--- a/providers/capa/cilium-eni-mode/capa_test.go
+++ b/providers/capa/cilium-eni-mode/capa_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/giantswarm/cluster-test-suites/internal/common"
+	"github.com/giantswarm/cluster-test-suites/internal/ecr"
 	"github.com/giantswarm/cluster-test-suites/internal/state"
 )
 
@@ -21,6 +22,9 @@ var _ = Describe("Cilium ENI mode tests", func() {
 		ExternalDnsSupported:         true,
 		ControlPlaneMetricsSupported: true,
 	})
+
+	// ECR Credential Provider specific tests
+	ecr.Run()
 
 	runSecondaryPodIPs()
 })

--- a/providers/capa/private/capa_test.go
+++ b/providers/capa/private/capa_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 
 	"github.com/giantswarm/cluster-test-suites/internal/common"
+	"github.com/giantswarm/cluster-test-suites/internal/ecr"
 )
 
 var _ = Describe("Common tests", func() {
@@ -14,4 +15,7 @@ var _ = Describe("Common tests", func() {
 		ExternalDnsSupported:         true,
 		ControlPlaneMetricsSupported: true,
 	})
+
+	// ECR Credential Provider specific tests
+	ecr.Run()
 })

--- a/providers/capa/standard/capa_test.go
+++ b/providers/capa/standard/capa_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 
 	"github.com/giantswarm/cluster-test-suites/internal/common"
+	"github.com/giantswarm/cluster-test-suites/internal/ecr"
 )
 
 var _ = Describe("Common tests", func() {
@@ -14,4 +15,7 @@ var _ = Describe("Common tests", func() {
 		ExternalDnsSupported:         true,
 		ControlPlaneMetricsSupported: true,
 	})
+
+	// ECR Credential Provider specific tests
+	ecr.Run()
 })

--- a/providers/capa/upgrade/capa_test.go
+++ b/providers/capa/upgrade/capa_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 
 	"github.com/giantswarm/cluster-test-suites/internal/common"
+	"github.com/giantswarm/cluster-test-suites/internal/ecr"
 	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
 )
 
@@ -18,4 +19,7 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 		ExternalDnsSupported:         true,
 		ControlPlaneMetricsSupported: true,
 	})
+
+	// ECR Credential Provider specific tests
+	ecr.Run()
 })


### PR DESCRIPTION
### What this PR does

Adds a CAPA-specific test case to test pulling images from a private ECR repository. 

Example output:
```
Common tests ecr credential provider should be able to pull an image from a private ECR registry
/app/internal/ecr/ecr.go:46
  {"level":"info","ts":"2024-10-07T14:58:23Z","msg":"Creating deployment with private ECR image..."}
  {"level":"info","ts":"2024-10-07T14:58:23Z","msg":"Checking status of deployments replicas..."}
  {"level":"info","ts":"2024-10-07T14:58:23Z","msg":"Deployment isn't yet ready - it currently has no replicas"}
  {"level":"info","ts":"2024-10-07T14:58:33Z","msg":"Checking status of deployments replicas..."}
  {"level":"info","ts":"2024-10-07T14:58:33Z","msg":"Deployment has 1 ready pod replicas"}
  {"level":"info","ts":"2024-10-07T14:58:33Z","msg":"Deleting deployment..."}
• [10.244 seconds]
```

Closes https://github.com/giantswarm/roadmap/issues/3702

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
