### PR TITLE
Add debugging of Cluster CR on standup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Debug the Cluster CR status when the workload cluster fails to standup correctly during `BeforeSuite`
+
 ## [1.73.0] - 2024-10-11
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.31.1
 	k8s.io/apimachinery v0.31.1
 	k8s.io/client-go v0.31.1
+	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6
 	sigs.k8s.io/cluster-api v1.8.4
 	sigs.k8s.io/controller-runtime v0.19.0
 )
@@ -197,7 +198,6 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241009091222-67ed5848f094 // indirect
 	k8s.io/kubectl v0.31.1 // indirect
-	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6 // indirect
 	oras.land/oras-go v1.2.6 // indirect
 	sigs.k8s.io/e2e-framework v0.4.0 // indirect
 	sigs.k8s.io/gateway-api v1.2.0 // indirect


### PR DESCRIPTION
### What this PR does

Include some extra debugging of the WCs Cluster CR status when the cluster fails to standup.

Example output:

```
  {"level":"info","ts":"2024-10-11T16:35:34+01:00","msg":"Attempting to get debug info for Cluster App"}
  {"level":"info","ts":"2024-10-11T16:35:34+01:00","msg":"Cluster App status: AppVersion='', Version='0.61.0', ReleaseStatus='deployed', ReleaseReason='', LastDeployed='2024-10-11 16:16:02 +0100 BST'"}
  {"level":"info","ts":"2024-10-11T16:35:34+01:00","msg":"Getting events for the Cluster App"}
  {"level":"info","ts":"2024-10-11T16:35:34+01:00","msg":"No events found for Cluster App"}
  {"level":"info","ts":"2024-10-11T16:35:34+01:00","msg":"Getting Cluster CR for the Cluster App"}
  {"level":"info","ts":"2024-10-11T16:35:34+01:00","msg":"Cluster status: Phase='Provisioned', InfrastructureReady='true', ControlPlaneReady='false', FailureReason='', FailureMessage=''"}
  {"level":"info","ts":"2024-10-11T16:35:34+01:00","msg":"Cluster condition with type 'Ready' and status 'False' - Message='Scaling up control plane to 3 replicas (actual 1)', Reason='ScalingUp', Last Occurred='2024-10-11 16:16:44 +0100 BST'"}
  {"level":"info","ts":"2024-10-11T16:35:34+01:00","msg":"Cluster condition with type 'ControlPlaneInitialized' and status 'False' - Message='Waiting for control plane provider to indicate the control plane has been initialized', Reason='WaitingForControlPlaneProviderInitialized', Last Occurred='2024-10-11 16:16:03 +0100 BST'"}
  {"level":"info","ts":"2024-10-11T16:35:34+01:00","msg":"Cluster condition with type 'ControlPlaneReady' and status 'False' - Message='Scaling up control plane to 3 replicas (actual 1)', Reason='ScalingUp', Last Occurred='2024-10-11 16:16:44 +0100 BST'"}
  {"level":"info","ts":"2024-10-11T16:35:34+01:00","msg":"Cluster condition with type 'InfrastructureReady' and status 'True' - Message='', Reason='', Last Occurred='2024-10-11 16:16:18 +0100 BST'"}
```

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
