### PR TITLE
Updated clustertest and cluster-standup-teardown to support cluster-cloud-director as a unified app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `clustertest` and `cluster-standup-teardown` to support `cluster-cloud-director` as a unified app
+
 ## [1.74.0] - 2024-10-15
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ replace github.com/alessio/shellescape => al.essio.dev/pkg/shellescape v1.4.2
 require (
 	github.com/cert-manager/cert-manager v1.16.1
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/cluster-standup-teardown v1.25.8
-	github.com/giantswarm/clustertest v1.28.0
+	github.com/giantswarm/cluster-standup-teardown v1.26.0
+	github.com/giantswarm/clustertest v1.29.0
 	github.com/gravitational/teleport/api v0.0.0-20241020172545-fc7bd616613a
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2

--- a/go.sum
+++ b/go.sum
@@ -784,10 +784,10 @@ github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXE
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/cluster-standup-teardown v1.25.8 h1:HYup5T96UB54UZUmHJxOiAGikV11KXj6IluF7sp7Nc0=
-github.com/giantswarm/cluster-standup-teardown v1.25.8/go.mod h1:B79V2m/YK/rWyz5YsSUUegj3K+o1zrc4hPznBTaRCMs=
-github.com/giantswarm/clustertest v1.28.0 h1:t1dpe4auVul1Rv/J0izozjj1WoCpPDcpe2fhzskNf/o=
-github.com/giantswarm/clustertest v1.28.0/go.mod h1:E3tJ0pz3E2q21jmGSyR5aU62GA8kUUEOl3+yO8ppItQ=
+github.com/giantswarm/cluster-standup-teardown v1.26.0 h1:PYbz+WwRh2e4EQ8CpQYPK2sBxOaYxRAKeB9MBjKlfpc=
+github.com/giantswarm/cluster-standup-teardown v1.26.0/go.mod h1:PZj83oUVj/le1ZrMAFQg/yhno9vcSqRSWIY19nmJbnM=
+github.com/giantswarm/clustertest v1.29.0 h1:TxLGyL721MyC6+wMjzU2UwnToNoKkbS6dqWvwFpt0I8=
+github.com/giantswarm/clustertest v1.29.0/go.mod h1:E3tJ0pz3E2q21jmGSyR5aU62GA8kUUEOl3+yO8ppItQ=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=
 github.com/giantswarm/k8smetadata v0.25.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.57.0 h1:IMmho55Qq+WE+frJXcTBhx19+J54xwu/j4+pGU5YecA=


### PR DESCRIPTION
### What this PR does

towards https://github.com/giantswarm/giantswarm/issues/31701

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
