### PR TITLE
Updated cluster-standup-teardown to 1.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `cluster-standup-teardown` to 1.26.1
+
 ## [1.75.0] - 2024-10-22
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/alessio/shellescape => al.essio.dev/pkg/shellescape v1.4.2
 require (
 	github.com/cert-manager/cert-manager v1.16.1
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/cluster-standup-teardown v1.26.0
+	github.com/giantswarm/cluster-standup-teardown v1.26.1
 	github.com/giantswarm/clustertest v1.29.0
 	github.com/gravitational/teleport/api v0.0.0-20241020172545-fc7bd616613a
 	github.com/onsi/ginkgo/v2 v2.21.0

--- a/go.sum
+++ b/go.sum
@@ -784,8 +784,8 @@ github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXE
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/cluster-standup-teardown v1.26.0 h1:PYbz+WwRh2e4EQ8CpQYPK2sBxOaYxRAKeB9MBjKlfpc=
-github.com/giantswarm/cluster-standup-teardown v1.26.0/go.mod h1:PZj83oUVj/le1ZrMAFQg/yhno9vcSqRSWIY19nmJbnM=
+github.com/giantswarm/cluster-standup-teardown v1.26.1 h1:ZBivFKfvXJI7kyrSrr2xG64XXjJE92nXYB1DymHyhe4=
+github.com/giantswarm/cluster-standup-teardown v1.26.1/go.mod h1:5EM/wsK4FtSH9a71yi+EBEDWD+YBAJY3ZtDl9lVFu/8=
 github.com/giantswarm/clustertest v1.29.0 h1:TxLGyL721MyC6+wMjzU2UwnToNoKkbS6dqWvwFpt0I8=
 github.com/giantswarm/clustertest v1.29.0/go.mod h1:E3tJ0pz3E2q21jmGSyR5aU62GA8kUUEOl3+yO8ppItQ=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=


### PR DESCRIPTION
### What this PR does

- updates cluster-standup-teardown to 1.26.1

### Checklist

- [x] Update changelog in CHANGELOG.md.

Test suites won't pass because this update is required to allow the vsphere test suite to pass.
