### PR TITLE
Skip EKS test suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Marked the EKS tests as skipped / pending until we re-focus on them again
+
 ## [1.76.2] - 2024-11-07
 
 ### Changed

--- a/providers/eks/standard/eks_test.go
+++ b/providers/eks/standard/eks_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = Describe("Common tests", func() {
+var _ = XDescribe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		AutoScalingSupported: true,
 		BastionSupported:     false,

--- a/providers/eks/upgrade/eks_test.go
+++ b/providers/eks/upgrade/eks_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
 )
 
-var _ = Describe("Basic upgrade test", Ordered, func() {
+var _ = XDescribe("Basic upgrade test", Ordered, func() {
 	upgrade.Run(upgrade.NewTestConfigWithDefaults())
 
 	// Finally run the common tests after upgrade is completed


### PR DESCRIPTION
### What this PR does

The EKS test sites have been flakey lately and a race condition is occasionally causing them to fail. As we currently aren't putting any effort into EKS I'm disabling these test suites for the time being until we decide to pick up the work on cluster-eks again.

Related: https://github.com/giantswarm/giantswarm/issues/31706 & https://github.com/giantswarm/roadmap/issues/3741

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
