### PR TITLE
Skip capv-on-capa and capv-on-capz tests until we can figure out VPN routing to the new vSphere provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Skip `capv-on-capa` and `capv-on-capz` tests until we can figure out VPN routing to the new vSphere provider
+
 ## [1.76.3] - 2024-11-08
 
 ### Changed

--- a/providers/capv/on-capa/capv_test.go
+++ b/providers/capv/on-capa/capv_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = Describe("Common tests", func() {
+var _ = XDescribe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		// No autoscaling on-prem
 		AutoScalingSupported: false,

--- a/providers/capv/on-capz/capv_test.go
+++ b/providers/capv/on-capz/capv_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 )
 
-var _ = Describe("Common tests", func() {
+var _ = XDescribe("Common tests", func() {
 	common.Run(&common.TestConfig{
 		// No autoscaling on-prem
 		AutoScalingSupported: false,


### PR DESCRIPTION
### What this PR does

towards https://github.com/giantswarm/giantswarm/issues/32054

### Checklist

- [x] Update changelog in CHANGELOG.md.
