### PR TITLE
Bump cluster-standup-teardown to v1.27.3 to update CAPV cluster values for the new vSphere provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Skip `capv-on-capa` and `capv-on-capz` tests until we can figure out VPN routing to the new vSphere provider
+- Bump `cluster-standup-teardown` to v1.27.3 to update CAPV cluster values for the new vSphere provider
 
 ## [1.76.3] - 2024-11-08
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/alessio/shellescape => al.essio.dev/pkg/shellescape v1.4.2
 require (
 	github.com/cert-manager/cert-manager v1.16.1
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/cluster-standup-teardown v1.27.2
+	github.com/giantswarm/cluster-standup-teardown v1.27.3
 	github.com/giantswarm/clustertest v1.30.2
 	github.com/gravitational/teleport/api v0.0.0-20241020172545-fc7bd616613a
 	github.com/onsi/ginkgo/v2 v2.21.0

--- a/go.sum
+++ b/go.sum
@@ -784,8 +784,8 @@ github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXE
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/cluster-standup-teardown v1.27.2 h1:KUbDa5/rEZAjrVMo6bDrs1DaT2bp3hTGd1KmAv6atAs=
-github.com/giantswarm/cluster-standup-teardown v1.27.2/go.mod h1:VJQQBx7hQpR9QnFDWunocVJUuVcAsYieocR+/eOGevo=
+github.com/giantswarm/cluster-standup-teardown v1.27.3 h1:AoyV6gJm/TKXecUanxenDSU8fBNLxVI76YH4gZQmvyY=
+github.com/giantswarm/cluster-standup-teardown v1.27.3/go.mod h1:VJQQBx7hQpR9QnFDWunocVJUuVcAsYieocR+/eOGevo=
 github.com/giantswarm/clustertest v1.30.2 h1:zPiXAf12AG5lU/SBG7aoN/JohaZFnE0OIzMG9rgjOlQ=
 github.com/giantswarm/clustertest v1.30.2/go.mod h1:41BvUGnuAXlTT5cbGLuZCSUSMVO7zz46qpvfhdK2nV8=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=


### PR DESCRIPTION
### What this PR does

towards https://github.com/giantswarm/giantswarm/issues/32054

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
