### PR TITLE
Allow to override `ClusterReady` timeout for cluster upgrade test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow to override `ClusterReady` timeout for cluster upgrade test
+
 ## [1.76.4] - 2024-11-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Allow to override `ClusterReady` timeout for cluster upgrade test
+- Set CAPVCD `ClusterReady` timeout to 25Min in upgrade test
 
 ## [1.76.4] - 2024-11-14
 

--- a/internal/timeout/consts.go
+++ b/internal/timeout/consts.go
@@ -3,4 +3,6 @@ package timeout
 const (
 	// DeployApps is used by "all default apps are deployed without issues"
 	DeployApps TestKey = "deployAppsTimeout"
+	// UpgradeClusterReadyTimeout is used by "upgrade cluster" has Cluster Ready condition with Status='True'
+	UpgradeClusterReadyTimeout TestKey = "upgradeClusterReadyTimeout"
 )

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/giantswarm/cluster-test-suites/internal/common"
 	"github.com/giantswarm/cluster-test-suites/internal/state"
+	"github.com/giantswarm/cluster-test-suites/internal/timeout"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -85,10 +86,13 @@ func Run(cfg *TestConfig) {
 		})
 
 		It("has Cluster Ready condition with Status='True'", func() {
+			// Overriding the default timeout, when upgradeClusterReadyTimeout is set
+			timeout := state.GetTestTimeout(timeout.UpgradeClusterReadyTimeout, 15*time.Minute)
+
 			mcClient := state.GetFramework().MC()
 			cluster := state.GetCluster()
 			Eventually(wait.IsClusterConditionSet(state.GetContext(), mcClient, cluster.Name, cluster.GetNamespace(), capi.ReadyCondition, corev1.ConditionTrue, "")).
-				WithTimeout(15 * time.Minute).
+				WithTimeout(timeout).
 				WithPolling(wait.DefaultInterval).
 				Should(BeTrue())
 		})

--- a/providers/capvcd/upgrade/capvcd_test.go
+++ b/providers/capvcd/upgrade/capvcd_test.go
@@ -13,7 +13,7 @@ import (
 
 var _ = Describe("Basic upgrade test", Ordered, func() {
 	BeforeEach(func() {
-		// Set the timeout for cluster ready to 25 minutes for CAPVCD
+		// Set the timeout for `ClusterReady` check to 25 minutes when upgrading the cluster
 		state.SetTestTimeout(timeout.UpgradeClusterReadyTimeout, time.Minute*25)
 	})
 	// it is better to get defaults at first and then customize

--- a/providers/capvcd/upgrade/capvcd_test.go
+++ b/providers/capvcd/upgrade/capvcd_test.go
@@ -6,10 +6,16 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 
 	"github.com/giantswarm/cluster-test-suites/internal/common"
+	"github.com/giantswarm/cluster-test-suites/internal/state"
+	"github.com/giantswarm/cluster-test-suites/internal/timeout"
 	"github.com/giantswarm/cluster-test-suites/internal/upgrade"
 )
 
 var _ = Describe("Basic upgrade test", Ordered, func() {
+	BeforeEach(func() {
+		// Set the timeout for cluster ready to 25 minutes for CAPVCD
+		state.SetTestTimeout(timeout.UpgradeClusterReadyTimeout, time.Minute*25)
+	})
 	// it is better to get defaults at first and then customize
 	// further changes in defaults will be effective here.
 	cfg := upgrade.NewTestConfigWithDefaults()


### PR DESCRIPTION
Towards: https://github.com/giantswarm/releases/pull/1490

### What this PR does


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites