### PR TITLE
Set CAPVCD `ClusterReady` timeout to 25Min in basic test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set CAPVCD `ClusterReady` timeout to 25Min in basic test
+
 ## [1.77.0] - 2024-11-19
 
 ### Changed

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -11,6 +11,7 @@ import (
 	cr "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/cluster-test-suites/internal/state"
+	"github.com/giantswarm/cluster-test-suites/internal/timeout"
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/client"
 	"github.com/giantswarm/clustertest/pkg/failurehandler"
@@ -155,10 +156,13 @@ func runBasic() {
 		})
 
 		It("has Cluster Ready condition with Status='True'", func() {
+			// Overriding the default timeout, when ClusterReadyTimeout is set
+			timeout := state.GetTestTimeout(timeout.ClusterReadyTimeout, 15*time.Minute)
+
 			mcClient := state.GetFramework().MC()
 			cluster := state.GetCluster()
 			Eventually(wait.IsClusterConditionSet(state.GetContext(), mcClient, cluster.Name, cluster.GetNamespace(), capi.ReadyCondition, corev1.ConditionTrue, "")).
-				WithTimeout(15 * time.Minute).
+				WithTimeout(timeout).
 				WithPolling(wait.DefaultInterval).
 				Should(BeTrue())
 		})

--- a/internal/timeout/consts.go
+++ b/internal/timeout/consts.go
@@ -3,6 +3,6 @@ package timeout
 const (
 	// DeployApps is used by "all default apps are deployed without issues"
 	DeployApps TestKey = "deployAppsTimeout"
-	// UpgradeClusterReadyTimeout is used by "upgrade cluster" has Cluster Ready condition with Status='True'
-	UpgradeClusterReadyTimeout TestKey = "upgradeClusterReadyTimeout"
+	// ClusterReadyTimeout is used by "has Cluster Ready condition with Status='True'"
+	ClusterReadyTimeout TestKey = "clusterReadyTimeout"
 )

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -86,8 +86,8 @@ func Run(cfg *TestConfig) {
 		})
 
 		It("has Cluster Ready condition with Status='True'", func() {
-			// Overriding the default timeout, when upgradeClusterReadyTimeout is set
-			timeout := state.GetTestTimeout(timeout.UpgradeClusterReadyTimeout, 15*time.Minute)
+			// Overriding the default timeout, when clusterReadyTimeout is set
+			timeout := state.GetTestTimeout(timeout.ClusterReadyTimeout, 15*time.Minute)
 
 			mcClient := state.GetFramework().MC()
 			cluster := state.GetCluster()

--- a/providers/capvcd/upgrade/capvcd_test.go
+++ b/providers/capvcd/upgrade/capvcd_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("Basic upgrade test", Ordered, func() {
 	BeforeEach(func() {
 		// Set the timeout for `ClusterReady` check to 25 minutes when upgrading the cluster
-		state.SetTestTimeout(timeout.UpgradeClusterReadyTimeout, time.Minute*25)
+		state.SetTestTimeout(timeout.ClusterReadyTimeout, time.Minute*25)
 	})
 	// it is better to get defaults at first and then customize
 	// further changes in defaults will be effective here.


### PR DESCRIPTION
### What this PR does


### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites