### PR TITLE
Increase CAPVCD `ClusterReady` timeout to 40Min

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Increase CAPVCD `ClusterReady` timeout to 40Min 
+
 ## [1.78.0] - 2024-11-19
 
 ### Changed

--- a/providers/capvcd/upgrade/capvcd_test.go
+++ b/providers/capvcd/upgrade/capvcd_test.go
@@ -13,8 +13,8 @@ import (
 
 var _ = Describe("Basic upgrade test", Ordered, func() {
 	BeforeEach(func() {
-		// Set the timeout for `ClusterReady` check to 25 minutes when upgrading the cluster
-		state.SetTestTimeout(timeout.ClusterReadyTimeout, time.Minute*25)
+		// Set the timeout for `ClusterReady` check to 40 minutes when upgrading the cluster
+		state.SetTestTimeout(timeout.ClusterReadyTimeout, time.Minute*40)
 	})
 	// it is better to get defaults at first and then customize
 	// further changes in defaults will be effective here.


### PR DESCRIPTION
### What this PR does


### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites