### PR TITLE
Bump `cluster-standup-teardown` to v1.27.4 to use lower lifecycle hooks heartbeat timeout to allow spot instances to terminate more quickly (CAPA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `cluster-standup-teardown` to v1.27.4 to use lower lifecycle hooks heartbeat timeout to allow spot instances to terminate more quickly (CAPA)
+
 ## [1.81.0] - 2024-11-29
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/alessio/shellescape => al.essio.dev/pkg/shellescape v1.4.2
 require (
 	github.com/cert-manager/cert-manager v1.16.2
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/cluster-standup-teardown v1.27.3
+	github.com/giantswarm/cluster-standup-teardown v1.27.4
 	github.com/giantswarm/clustertest v1.31.0
 	github.com/giantswarm/k8smetadata v0.25.0
 	github.com/gravitational/teleport/api v0.0.0-20241209023627-0feb6fea7cdd

--- a/go.sum
+++ b/go.sum
@@ -782,8 +782,8 @@ github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXE
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/cluster-standup-teardown v1.27.3 h1:AoyV6gJm/TKXecUanxenDSU8fBNLxVI76YH4gZQmvyY=
-github.com/giantswarm/cluster-standup-teardown v1.27.3/go.mod h1:VJQQBx7hQpR9QnFDWunocVJUuVcAsYieocR+/eOGevo=
+github.com/giantswarm/cluster-standup-teardown v1.27.4 h1:X8m5y/0DC1PlCr5E7GiqqsLUBcJ42IeMgRp7W6G/RyM=
+github.com/giantswarm/cluster-standup-teardown v1.27.4/go.mod h1:TPeluSpDGdZrxC6pw3DfqgREO5eotqjIctoHsJUcYZU=
 github.com/giantswarm/clustertest v1.31.0 h1:KNUj7V6tyuGa+SZ2ET0xPedGUH14X2qhHjFSTCi/PTM=
 github.com/giantswarm/clustertest v1.31.0/go.mod h1:GArUIc4mzgVmweaLx67X/YHm3G5jJrHsP7ttPSUFepM=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=


### PR DESCRIPTION
### What this PR does

Use https://github.com/giantswarm/cluster-standup-teardown/pull/173 to prevent test from timing out because EC2 spot instances can't terminate quickly.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

Chicken-egg problem, so I'll run these on the cluster-aws PR instead.