### PR TITLE
Added test for CrashLooping pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a new test case to check for pods CrashLooping
+
 ### Changed
 
 - Re-enable `capv-on-capa` and `capv-on-capz` tests

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -158,9 +158,9 @@ func runBasic() {
 		It("doesn't have restarting pods", func() {
 			Eventually(
 				wait.ConsistentWaitCondition(
-					wait.AreNoPodsCrashLooping(state.GetContext(), wcClient, 3),
+					wait.AreNoPodsCrashLooping(state.GetContext(), wcClient, 2),
 					10,
-					time.Second,
+					5*time.Second,
 				)).
 				WithTimeout(15*time.Minute).
 				WithPolling(wait.DefaultInterval).

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -155,6 +155,21 @@ func runBasic() {
 				)
 		})
 
+		It("doesn't have restarting pods", func() {
+			Eventually(
+				wait.ConsistentWaitCondition(
+					wait.AreNoPodsCrashLooping(state.GetContext(), wcClient, 3),
+					10,
+					time.Second,
+				)).
+				WithTimeout(15*time.Minute).
+				WithPolling(wait.DefaultInterval).
+				Should(
+					Succeed(),
+					failurehandler.PodsNotReady(state.GetFramework(), state.GetCluster()),
+				)
+		})
+
 		It("has Cluster Ready condition with Status='True'", func() {
 			// Overriding the default timeout, when ClusterReadyTimeout is set
 			timeout := state.GetTestTimeout(timeout.ClusterReadyTimeout, 15*time.Minute)


### PR DESCRIPTION
### What this PR does

Fixes: https://github.com/giantswarm/giantswarm/issues/32317

Adds a new common test to check for pods with containers that have restarted more than 3 times.

Example:

```
Common tests basic doesn't have restarting pods
/app/internal/common/basic.go:158
  {"level":"info","ts":"2025-01-06T15:28:36Z","msg":"All (72) pods have containers with less restarts than the max allowed (3)"}
  {"level":"info","ts":"2025-01-06T15:28:37Z","msg":"All (72) pods have containers with less restarts than the max allowed (3)"}
  {"level":"info","ts":"2025-01-06T15:28:38Z","msg":"All (72) pods have containers with less restarts than the max allowed (3)"}
  {"level":"info","ts":"2025-01-06T15:28:39Z","msg":"All (72) pods have containers with less restarts than the max allowed (3)"}
  {"level":"info","ts":"2025-01-06T15:28:40Z","msg":"All (72) pods have containers with less restarts than the max allowed (3)"}
  {"level":"info","ts":"2025-01-06T15:28:41Z","msg":"All (72) pods have containers with less restarts than the max allowed (3)"}
  {"level":"info","ts":"2025-01-06T15:28:42Z","msg":"All (72) pods have containers with less restarts than the max allowed (3)"}
  {"level":"info","ts":"2025-01-06T15:28:43Z","msg":"All (72) pods have containers with less restarts than the max allowed (3)"}
  {"level":"info","ts":"2025-01-06T15:28:44Z","msg":"All (72) pods have containers with less restarts than the max allowed (3)"}
  {"level":"info","ts":"2025-01-06T15:28:45Z","msg":"All (72) pods have containers with less restarts than the max allowed (3)"}
• [11.000 seconds]
```

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
