### PR TITLE
Fix timeout not being respected during AfterSuite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bump `clustertest` to [v1.32.1](https://github.com/giantswarm/clustertest/releases/tag/v1.32.1) to fix timeout not being respected during `AfterSuite`.
+
 ## [1.83.0] - 2025-01-07
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cert-manager/cert-manager v1.16.2
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/giantswarm/cluster-standup-teardown v1.27.4
-	github.com/giantswarm/clustertest v1.32.0
+	github.com/giantswarm/clustertest v1.32.1
 	github.com/giantswarm/k8smetadata v0.25.0
 	github.com/gravitational/teleport/api v0.0.0-20250103223503-4ea35660e77f
 	github.com/onsi/ginkgo/v2 v2.22.2

--- a/go.sum
+++ b/go.sum
@@ -786,8 +786,8 @@ github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
 github.com/giantswarm/cluster-standup-teardown v1.27.4 h1:X8m5y/0DC1PlCr5E7GiqqsLUBcJ42IeMgRp7W6G/RyM=
 github.com/giantswarm/cluster-standup-teardown v1.27.4/go.mod h1:TPeluSpDGdZrxC6pw3DfqgREO5eotqjIctoHsJUcYZU=
-github.com/giantswarm/clustertest v1.32.0 h1:j0hsCJ4pWA+bEbgGG3qyx3wZ9HQMr/0qGpITZdZCldw=
-github.com/giantswarm/clustertest v1.32.0/go.mod h1:hNuX2ifImtzySCPu3KxSUO7cnuBRTLxzKjCsxCdKt0E=
+github.com/giantswarm/clustertest v1.32.1 h1:O359XcoK7M2osK8HupB3kkS6+NR9IpQai4fHEUiwkDk=
+github.com/giantswarm/clustertest v1.32.1/go.mod h1:V+2IV6zy4XjWzmy6/Ds9OW3Y8M9kmFyF2hZuSAUTqAY=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=
 github.com/giantswarm/k8smetadata v0.25.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.57.0 h1:IMmho55Qq+WE+frJXcTBhx19+J54xwu/j4+pGU5YecA=


### PR DESCRIPTION
### What this PR does

Bump `clustertest` to [v1.32.1](https://github.com/giantswarm/clustertest/releases/tag/v1.32.1) to fix timeout not being respected during `AfterSuite`. The timeout of 1 hour should now be respected and should cut down on leftover resources, especially from the CAPA China test suite.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
