### PR TITLE
Refactor storage tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored the storage test with the following changes:
+  - Split into individual it block for more fine-grained failures
+  - Added logging to show progress of tests while running
+  - Ensured the PersistentVolume is deleted before continuing to ensure we don't accidentally leave behind disks
+
 ## [1.83.1] - 2025-01-09
 
 ### Fixed


### PR DESCRIPTION
### What this PR does

- Refactored the storage test with the following changes:
  - Split into individual it block for more fine-grained failures
  - Added logging to show progress of tests while running
  - Ensured the PersistentVolume is deleted before continuing to ensure we don't accidentally leave behind disks

Towards: https://github.com/giantswarm/roadmap/issues/3838

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
