### PR TITLE
Improved PV cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure the storage test waits until PV has been fully deleted
+
+### Added
+
+- Attempt to delete any remaining PVs during `AfterSuite` before the cluster itself is removed to try to avoid leaving cloud volumes behind.
+
 ## [1.84.0] - 2025-01-17
 
 ### Changed

--- a/internal/common/storage.go
+++ b/internal/common/storage.go
@@ -182,12 +182,17 @@ func runStorage() {
 								logger.Log("Failed to delete PersistentVolume '%s'", pvName)
 								return err
 							}
+
+							Eventually(wait.IsResourceDeleted(state.GetContext(), wcClient, &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: pvName}})).
+								WithTimeout(5 * time.Minute).
+								WithPolling(wait.DefaultInterval).
+								Should(BeTrue())
 						}
 
 						logger.Log("All associated resources deleted")
 						return nil
 					}).
-					WithTimeout(5 * time.Minute).
+					WithTimeout(15 * time.Minute).
 					WithPolling(wait.DefaultInterval).
 					Should(Succeed())
 			})


### PR DESCRIPTION
### What this PR does

Fixed

- Ensure the storage test waits until PV has been fully deleted

Added

- Attempt to delete any remaining PVs during `AfterSuite` before the cluster itself is removed to try to avoid leaving cloud volumes behind.


Fixes: https://github.com/giantswarm/roadmap/issues/3838

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
