### PR TITLE
Stop using spot instances for CAPA WCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Attempt to delete any remaining PVs during `AfterSuite` before the cluster itself is removed to try to avoid leaving cloud volumes behind.
 
+### Changed
+
+- Updated `cluster-standup-teardown` to stop using spot instances for CAPA WCs
+
 ## [1.84.0] - 2025-01-17
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/alessio/shellescape => al.essio.dev/pkg/shellescape v1.4.2
 require (
 	github.com/cert-manager/cert-manager v1.16.3
 	github.com/giantswarm/apiextensions-application v0.6.2
-	github.com/giantswarm/cluster-standup-teardown v1.27.4
+	github.com/giantswarm/cluster-standup-teardown v1.28.0
 	github.com/giantswarm/clustertest v1.32.1
 	github.com/giantswarm/k8smetadata v0.25.0
 	github.com/gravitational/teleport/api v0.0.0-20250117223510-1b76f9743e16

--- a/go.sum
+++ b/go.sum
@@ -784,8 +784,8 @@ github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXE
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/cluster-standup-teardown v1.27.4 h1:X8m5y/0DC1PlCr5E7GiqqsLUBcJ42IeMgRp7W6G/RyM=
-github.com/giantswarm/cluster-standup-teardown v1.27.4/go.mod h1:TPeluSpDGdZrxC6pw3DfqgREO5eotqjIctoHsJUcYZU=
+github.com/giantswarm/cluster-standup-teardown v1.28.0 h1:Nd79QEGg5dBkP6y+wjNFhYogpP1N5EszhBiN+Kijtnc=
+github.com/giantswarm/cluster-standup-teardown v1.28.0/go.mod h1:rcphAB/qFVPYeJF2pbTzqj3v+ltx05ZGKNFk1lZZS90=
 github.com/giantswarm/clustertest v1.32.1 h1:O359XcoK7M2osK8HupB3kkS6+NR9IpQai4fHEUiwkDk=
 github.com/giantswarm/clustertest v1.32.1/go.mod h1:V+2IV6zy4XjWzmy6/Ds9OW3Y8M9kmFyF2hZuSAUTqAY=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=


### PR DESCRIPTION
### What this PR does

Towards: https://github.com/giantswarm/giantswarm/issues/32434

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
