### PR TITLE
Show debug info if `Deployment` with private ECR image failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Attempt to delete any remaining PVs during `AfterSuite` before the cluster itself is removed to try to avoid leaving cloud volumes behind.
+- Show debug info if `Deployment` with private ECR image failed
 
 ### Changed
 

--- a/internal/ecr/ecr.go
+++ b/internal/ecr/ecr.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/giantswarm/clustertest/pkg/client"
+	"github.com/giantswarm/clustertest/pkg/failurehandler"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/wait"
 	appsv1 "k8s.io/api/apps/v1"
@@ -83,9 +84,10 @@ func Run() {
 
 				return nil
 			}).
-				WithTimeout(2 * time.Minute).
+				WithTimeout(2*time.Minute).
 				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
+				Should(Succeed(),
+					failurehandler.DeploymentsNotReady(state.GetFramework(), state.GetCluster()))
 
 			Eventually(func() error {
 				logger.Log("Deleting deployment...")


### PR DESCRIPTION
### What this PR does

See title. Without this, it's impossible to troubleshoot after the test ended.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites TARGET_SUITES=./providers/capa/standard
