### PR TITLE
Metrics: Replace deprecated `pod_scheduling_duration_seconds` by `scheduling_attempt_duration_seconds`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Metrics: Replace deprecated `pod_scheduling_duration_seconds` by `scheduling_attempt_duration_seconds`.
+
 ## [1.86.0] - 2025-01-22
 
 ### Changed

--- a/internal/common/metrics.go
+++ b/internal/common/metrics.go
@@ -65,8 +65,8 @@ func runMetrics(controlPlaneMetricsSupported bool) {
 					"workqueue_queue_duration_seconds_bucket",
 
 					// Scheduler
-					"scheduler_pod_scheduling_duration_seconds_count",
-					"scheduler_pod_scheduling_duration_seconds_bucket",
+					"scheduler_scheduling_attempt_duration_seconds_count",
+					"scheduler_scheduling_attempt_duration_seconds_bucket",
 
 					// ETCD
 					"etcd_request_duration_seconds_count",


### PR DESCRIPTION
### What this PR does

It replaces the deprecated `pod_scheduling_duration_seconds` metric by the `scheduling_attempt_duration_seconds`.

`pod_scheduling_duration_seconds` is no longer available by default in Kubernetes v1.30.x and there needs a successor, so we can still test scheduler metrics.

These metrics are not equal, but that does not matter here, as we are only checking if they exist.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
