### PR TITLE
Basic: Increase connection check flake attempts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Basic: Increase connection check flake attempts. ([#625](https://github.com/giantswarm/cluster-test-suites/pull/625))
+
 ## [1.87.0] - 2025-02-20
 
 ### Changed

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -39,7 +39,7 @@ func runBasic() {
 			Expect(state.GetFramework().MC().CheckConnection()).To(Succeed())
 		})
 
-		It("should be able to connect to the workload cluster", FlakeAttempts(3), func() {
+		It("should be able to connect to the workload cluster", FlakeAttempts(5), func() {
 			Expect(wcClient.CheckConnection()).To(Succeed())
 		})
 


### PR DESCRIPTION
### What this PR does

This PR increases the amount of flake attempts for the workload cluster connection check.

I've seen multiple runs where this test fails even though previous and following tests are all green.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
