### PR TITLE
Disable node-termination-handler in CAPA tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix linting issues.
 
+### Changed
+
+- Disable node-termination-handler in CAPA tests. See [giantswarm/giantswarm#32656](https://github.com/giantswarm/giantswarm/issues/32656)
+
 ## [1.87.2] - 2025-03-08
 
 ### Changed

--- a/providers/capa/china/test_data/cluster_values.yaml
+++ b/providers/capa/china/test_data/cluster_values.yaml
@@ -1,1 +1,4 @@
 # Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
+global:
+  providerSpecific:
+    nodeTerminationHandlerEnabled: false # https://github.com/giantswarm/giantswarm/issues/32656

--- a/providers/capa/cilium-eni-mode/test_data/cluster_values.yaml
+++ b/providers/capa/cilium-eni-mode/test_data/cluster_values.yaml
@@ -2,6 +2,7 @@
 global:
   providerSpecific:
     awsClusterRoleIdentityName: giantswarm-grizzly-wc-e2e
+    nodeTerminationHandlerEnabled: false # https://github.com/giantswarm/giantswarm/issues/32656
   connectivity:
     # These two settings enable Cilium ENI mode
     network:

--- a/providers/capa/private/test_data/cluster_values.yaml
+++ b/providers/capa/private/test_data/cluster_values.yaml
@@ -1,1 +1,4 @@
 # Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
+global:
+  providerSpecific:
+    nodeTerminationHandlerEnabled: false # https://github.com/giantswarm/giantswarm/issues/32656

--- a/providers/capa/standard/test_data/cluster_values.yaml
+++ b/providers/capa/standard/test_data/cluster_values.yaml
@@ -2,3 +2,4 @@
 global:
   providerSpecific:
     awsClusterRoleIdentityName: giantswarm-grizzly-wc-e2e
+    nodeTerminationHandlerEnabled: false # https://github.com/giantswarm/giantswarm/issues/32656

--- a/providers/capa/upgrade/test_data/cluster_values.yaml
+++ b/providers/capa/upgrade/test_data/cluster_values.yaml
@@ -1,6 +1,7 @@
 global:
   providerSpecific:
     awsClusterRoleIdentityName: giantswarm-grizzly-wc-e2e
+    nodeTerminationHandlerEnabled: false # https://github.com/giantswarm/giantswarm/issues/32656
   nodePools:
     # Here we override the default values from cluster-standup-teardown and make the following changes:
     #


### PR DESCRIPTION
### What this PR does

NTH may frequently restart during cluster creation due to IRSA operator being slow when creating the cluster openid provider in AWS. This makes the E2E tests fail regularly, although we consider it an expected situation. Until there's more granular control on the Pod restarting test conditions we'll disable NTH during E2E tests

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
