### PR TITLE
Change metric name from `apiserver_flowcontrol_request_concurrency_limit` to `apiserver_flowcontrol_nominal_limit_seats`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Disable node-termination-handler in CAPA tests. See [giantswarm/giantswarm#32656](https://github.com/giantswarm/giantswarm/issues/32656)
+- Change `apiserver_flowcontrol_request_concurrency_limit` to `apiserver_flowcontrol_nominal_limit_seats`. This metric name is dropped in Kubernetes `v1.31`.
 
 ## [1.87.2] - 2025-03-08
 

--- a/internal/common/metrics.go
+++ b/internal/common/metrics.go
@@ -53,7 +53,7 @@ func runMetrics(controlPlaneMetricsSupported bool) {
 				metrics = append(metrics, []string{
 					// API server metrics in prometheus-rules
 					"apiserver_flowcontrol_dispatched_requests_total",
-					"apiserver_flowcontrol_request_concurrency_limit",
+					"apiserver_flowcontrol_nominal_limit_seats",
 					"apiserver_request_duration_seconds_bucket",
 					"apiserver_admission_webhook_request_total",
 					"apiserver_admission_webhook_admission_duration_seconds_sum",


### PR DESCRIPTION
### What this PR does

E2e tests currently failing for `v1.31` the metric name has to changed. It is backward compatible. The metric `apiserver_flowcontrol_request_concurrency_limit` does not exist in `v1.31`.

```
apiserver_flowcontrol_request_concurrency_limit
Nominal number of execution seats configured for each priority level
Stability Level:ALPHA
Type: Gauge
Labels:priority_level
Deprecated Versions:1.30.0
```
### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites