### PR TITLE
Increase Restart Limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase restart limit to 5. Some applications like cluster-autoscaler depend on IRSA and need additional time to start working properly.
+
 ## [1.88.0] - 2025-05-30
 
 ### Fixed

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -158,7 +158,7 @@ func runBasic() {
 		It("doesn't have restarting pods", func() {
 			Eventually(
 				wait.ConsistentWaitCondition(
-					wait.AreNoPodsCrashLooping(state.GetContext(), wcClient, 2),
+					wait.AreNoPodsCrashLooping(state.GetContext(), wcClient, 5),
 					10,
 					5*time.Second,
 				)).


### PR DESCRIPTION
### What this PR does

I am not sure if it's due to Crossplane being a little bit slower than IRSA Operator (I doubt it but I haven't really done much benchmarks here) but cluster-autoscaler is always taking 5 restarts in the Standard mode until it's working properly.

https://tekton.ci.giantswarm.io/#/namespaces/tekton-pipelines/pipelineruns/pr-cluster-aws-1146-cluster-test-suitesh8tcv?pipelineTask=run-tests&taskRunName=pr-cluster-aws-1146-cluster-test-suitesh8tcv-run-tests-3

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites
