### PR TITLE
Update capv-on-capa to use the new garm management cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `capz-on-capa` to use the new `garm` management cluster.
+
 ## [1.91.0] - 2025-07-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `capz-on-capa` to use the new `garm` management cluster.
+- Update `capv-on-capa` to use the new `garm` management cluster.
 
 ## [1.91.0] - 2025-07-10
 

--- a/providers/capv/on-capa/test_data/cluster_values.yaml
+++ b/providers/capv/on-capa/test_data/cluster_values.yaml
@@ -1,6 +1,6 @@
 # Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
 global:
   connectivity:
-    baseDomain: gaws.gigantic.io
+    baseDomain: gawsprivate.gigantic.io
     proxy:
       enabled: false


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/33674

we can't run the tests until the kubeconfig for the MC is updated in tekton.

### Checklist

- [x] Update changelog in CHANGELOG.md.

