### PR TITLE
Fix `Setup` function to properly handle the case where the first release of a new major version is being tested.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `Setup` function to properly handle the case where the first release of a new major version is being tested.
+
 ## [1.95.0] - 2025-08-19
 
 ### Changed
@@ -1110,8 +1114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example common tests
 - Dockerfile for running tests in CI
 
-[Unreleased]: https://github.com/giantswarm/cluster-test-suites/compare/v1.95.0...HEAD
-[1.95.0]: https://github.com/giantswarm/cluster-test-suites/compare/v1.94.0...v1.95.0
+[Unreleased]: https://github.com/giantswarm/cluster-test-suites/compare/v1.94.0...HEAD
 [1.94.0]: https://github.com/giantswarm/cluster-test-suites/compare/v1.93.0...v1.94.0
 [1.93.0]: https://github.com/giantswarm/cluster-test-suites/compare/v1.92.1...v1.93.0
 [1.92.1]: https://github.com/giantswarm/cluster-test-suites/compare/v1.92.0...v1.92.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1114,7 +1114,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example common tests
 - Dockerfile for running tests in CI
 
-[Unreleased]: https://github.com/giantswarm/cluster-test-suites/compare/v1.94.0...HEAD
+[Unreleased]: https://github.com/giantswarm/cluster-test-suites/compare/v1.95.0...HEAD
+[1.95.0]: https://github.com/giantswarm/cluster-test-suites/compare/v1.94.0...v1.95.0
 [1.94.0]: https://github.com/giantswarm/cluster-test-suites/compare/v1.93.0...v1.94.0
 [1.93.0]: https://github.com/giantswarm/cluster-test-suites/compare/v1.92.1...v1.93.0
 [1.92.1]: https://github.com/giantswarm/cluster-test-suites/compare/v1.92.0...v1.92.1

--- a/internal/suite/setup.go
+++ b/internal/suite/setup.go
@@ -57,6 +57,13 @@ func Setup(isUpgrade bool, clusterBuilder cb.ClusterBuilder, clusterReadyFns ...
 					return
 				}
 
+				// Check if we were looking for a previous major release but got an empty 'from' version.
+				// This happens when we're drafting the first release of a new major version.
+				if from == "" && os.Getenv(env.ReleasePreUpgradeVersion) == "previous_major" {
+					Skip("Skipping upgrade test as this is the first release of a new major version")
+					return
+				}
+
 				// Set the concrete, resolved versions back into the environment, so that they can be
 				// picked up by the cluster-standup-teardown library.
 				os.Setenv(env.ReleasePreUpgradeVersion, from)


### PR DESCRIPTION
### What this PR does


### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites