### PR TITLE
Add automatic node roll detection to upgrade tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add automatic node roll detection to upgrade tests. Test reports will now include whether a release upgrade caused nodes to be rolled.
+
 ## [1.95.6] - 2025-08-28
 
 ### Changed

--- a/internal/helper/report.go
+++ b/internal/helper/report.go
@@ -1,0 +1,12 @@
+package helper
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
+)
+
+// RecordNodeRolling annotates the current test spec with a boolean indicating if nodes were rolled during the test.
+func RecordNodeRolling(rolled bool) {
+	AddReportEntry("NODES_ROLLED", fmt.Sprintf("%t", rolled))
+}


### PR DESCRIPTION
### What this PR does

Towards: https://github.com/giantswarm/roadmap/issues/4003

Extending the upgrade test suite to automatically detect if nodes are rolled during a release upgrade.

### Changes:

A new test has been added to the upgrade suite that compares the set of cluster nodes before and after the upgrade is applied.

The result (true or false) is added to the Ginkgo test report under the `NODES_ROLLED` key.

This check can be disabled by setting the `SKIP_NODE_ROLL_DETECTION` environment variable, which is used to ignore expected node rolls (e.g., in "Previous Major" upgrade tests), because there we always roll the nodes.

A PR in `tekton-resources` will follow.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/run cluster-test-suites