### PR TITLE
fix: pin nginx-unprivileged image tag in PVC storage test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin `nginx-unprivileged` image tag to `1.31-alpine` in PVC storage test. The image had no `:latest` tag in `gsoci.azurecr.io`, causing the pod to fail with `ErrImagePull` and the test to time out across all providers.
+
 ## [7.0.1] - 2026-05-08
 
 ### Changed

--- a/assets/storage/storage.go
+++ b/assets/storage/storage.go
@@ -33,7 +33,7 @@ spec:
     runAsUser: 1001
   containers:
     - name: pvc-test-container
-      image: gsoci.azurecr.io/giantswarm/nginx-unprivileged
+      image: gsoci.azurecr.io/giantswarm/nginx-unprivileged:1.31-alpine
       volumeMounts:
         - name: test-volume
           mountPath: /data


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/C0561JVB0HY/p1779341812537889

The PVC storage test pod referenced `gsoci.azurecr.io/giantswarm/nginx-unprivileged` without a tag, defaulting to `:latest`. That tag does not exist in the registry (only versioned `*-alpine` tags do), so the pod failed with `ErrImagePull` and the "runs successfully" step timed out after 20 minutes across all providers.

Pinned to `1.31-alpine` — the newest tag available.