### PR TITLE
feat(tests): enable Gateway API e2e test across all providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CAPA standard suite: add an ASG-based ARM/Graviton node pool (`np-arm64`, `m7g.xlarge`) alongside the existing amd64 pools. It is tainted `kubernetes.io/arch=arm64:NoSchedule` so amd64-only workloads stay on the amd64 pools.
 - Add a temporary `ARMNodePoolEnabled` suite config flag. When set, the basic pod health checks ("Running state" and "restarting pods") exclude `net-exporter` and `cert-exporter-daemonset`, whose released app versions aren't multi-arch yet and crashloop on arm64 nodes. Enabled for the CAPA standard suite; to be removed once release v35 ships the multi-arch versions.
+- Add `hello world via gateway api` e2e test to CAPA suites. Deploys `gateway-api-bundle` and a `hello-world` app via `HTTPRoute`, verifying gateway, DNS, certificate, and HTTP connectivity end-to-end.
+- Extend the gateway API e2e test to capv, capz, capvcd, and EKS suites. Provider-specific steps (external-dns check, certificate readiness, HTTP test) are skipped when the underlying capability is not available.
 
 ## [7.1.0] - 2026-05-21
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fluxcd/helm-controller/api v1.5.5
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/giantswarm/cluster-standup-teardown/v6 v6.0.1
-	github.com/giantswarm/clustertest/v5 v5.1.0
+	github.com/giantswarm/clustertest/v5 v5.1.1-0.20260524063828-b0c31be2c916
 	github.com/giantswarm/k8smetadata v0.26.0
 	github.com/gravitational/teleport/api v0.0.0-20260525194042-be383ce680b6
 	github.com/onsi/ginkgo/v2 v2.29.0

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,6 @@ github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
 github.com/giantswarm/cluster-standup-teardown/v6 v6.0.1 h1:ElldQMFe02zlSHxbV1n2B+9xlwhR8cEKGe1XDIWu28w=
 github.com/giantswarm/cluster-standup-teardown/v6 v6.0.1/go.mod h1:ZWF1n73ButDUKW6uH0+GI4/iYOu4wlVonr0PiuUgt7o=
-github.com/giantswarm/clustertest/v5 v5.1.0 h1:B5EFecXSk1ZFdywlFPEB+WvMdLxs8jFcU58PVSjmNhA=
-github.com/giantswarm/clustertest/v5 v5.1.0/go.mod h1:Wix+WD6ETIk+qVm/U9O7Lj1BeqD5P0QlYnH+fEajuOU=
 github.com/giantswarm/clustertest/v5 v5.1.1-0.20260524063828-b0c31be2c916 h1:Rtt4qiHM6ewrOsMMOpmjmgVi7nH6NuBCw81hjKxUYns=
 github.com/giantswarm/clustertest/v5 v5.1.1-0.20260524063828-b0c31be2c916/go.mod h1:Wix+WD6ETIk+qVm/U9O7Lj1BeqD5P0QlYnH+fEajuOU=
 github.com/giantswarm/k8smetadata v0.26.0 h1:2TLymlfjYLyioRRimbm0CxRzEr5lMivsuEiE32+JYxQ=

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/giantswarm/cluster-standup-teardown/v6 v6.0.1 h1:ElldQMFe02zlSHxbV1n2
 github.com/giantswarm/cluster-standup-teardown/v6 v6.0.1/go.mod h1:ZWF1n73ButDUKW6uH0+GI4/iYOu4wlVonr0PiuUgt7o=
 github.com/giantswarm/clustertest/v5 v5.1.0 h1:B5EFecXSk1ZFdywlFPEB+WvMdLxs8jFcU58PVSjmNhA=
 github.com/giantswarm/clustertest/v5 v5.1.0/go.mod h1:Wix+WD6ETIk+qVm/U9O7Lj1BeqD5P0QlYnH+fEajuOU=
+github.com/giantswarm/clustertest/v5 v5.1.1-0.20260524063828-b0c31be2c916 h1:Rtt4qiHM6ewrOsMMOpmjmgVi7nH6NuBCw81hjKxUYns=
+github.com/giantswarm/clustertest/v5 v5.1.1-0.20260524063828-b0c31be2c916/go.mod h1:Wix+WD6ETIk+qVm/U9O7Lj1BeqD5P0QlYnH+fEajuOU=
 github.com/giantswarm/k8smetadata v0.26.0 h1:2TLymlfjYLyioRRimbm0CxRzEr5lMivsuEiE32+JYxQ=
 github.com/giantswarm/k8smetadata v0.26.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.57.0 h1:IMmho55Qq+WE+frJXcTBhx19+J54xwu/j4+pGU5YecA=

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -38,7 +38,7 @@ func Run(cfg *TestConfig) {
 	runMetrics(cfg)
 	runTeleport(cfg.TeleportSupported)
 	runHelloWorld(cfg.ExternalDnsSupported && cfg.IngressNginxSupported)
-	runHelloWorldGateway(cfg.GatewayAPISupported)
+	runHelloWorldGateway(cfg.GatewayAPISupported, cfg.ExternalDnsSupported, cfg.CertManagerSupported)
 	runScale(cfg.AutoScalingSupported)
 	runStorage()
 }

--- a/internal/common/hello_gateway.go
+++ b/internal/common/hello_gateway.go
@@ -143,6 +143,16 @@ func runHelloWorldGateway(gatewayAPISupported, externalDnsSupported, certManager
 				WithTimeout(10*time.Minute).
 				WithPolling(10*time.Second).
 				Should(BeTrue())
+
+			childApps := []types.NamespacedName{
+				{Name: fmt.Sprintf("%s-gateway-api-crds", clusterName), Namespace: namespace},
+				{Name: fmt.Sprintf("%s-envoy-gateway", clusterName), Namespace: namespace},
+				{Name: fmt.Sprintf("%s-gateway-api-config", clusterName), Namespace: namespace},
+			}
+			Eventually(wait.IsAllAppDeployed(state.GetContext(), state.GetFramework().MC(), childApps)).
+				WithTimeout(10*time.Minute).
+				WithPolling(10*time.Second).
+				Should(BeTrue())
 		})
 
 		It("gateway giantswarm-default should be programmed", func() {

--- a/internal/common/hello_gateway.go
+++ b/internal/common/hello_gateway.go
@@ -9,6 +9,7 @@ import (
 
 	certmanager "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	"github.com/giantswarm/clustertest/v5/pkg/failurehandler"
 	"github.com/giantswarm/clustertest/v5/pkg/helmrelease"
 	"github.com/giantswarm/clustertest/v5/pkg/logger"
 	"github.com/giantswarm/clustertest/v5/pkg/net"
@@ -217,7 +218,7 @@ func runHelloWorldGateway(gatewayAPISupported, externalDnsSupported, certManager
 			}).
 				WithTimeout(10 * time.Minute).
 				WithPolling(10 * time.Second).
-				Should(BeTrue())
+				Should(BeTrue(), failurehandler.ExternalDNSIssues(state.GetFramework(), state.GetCluster()))
 		})
 
 		It("certificate in envoy-gateway-system should be ready", func() {
@@ -263,6 +264,7 @@ func runHelloWorldGateway(gatewayAPISupported, externalDnsSupported, certManager
 				WithPolling(wait.DefaultInterval).
 				Should(
 					Succeed(),
+					failurehandler.CertificatesNotReady(state.GetFramework(), state.GetCluster(), "envoy-gateway-system"),
 				)
 		})
 

--- a/internal/common/hello_gateway.go
+++ b/internal/common/hello_gateway.go
@@ -24,7 +24,7 @@ import (
 	"github.com/giantswarm/cluster-test-suites/v7/internal/state"
 )
 
-func runHelloWorldGateway(gatewayAPISupported bool) {
+func runHelloWorldGateway(gatewayAPISupported, externalDnsSupported, certManagerSupported bool) {
 	Context("hello world via gateway api", Ordered, func() {
 		var (
 			helloHelmRelease    *helmv2.HelmRelease
@@ -49,17 +49,25 @@ func runHelloWorldGateway(gatewayAPISupported bool) {
 		})
 
 		It("should have cert-manager and external-dns deployed", func() {
+			if !certManagerSupported && !externalDnsSupported {
+				Skip("Neither cert-manager nor external-dns is supported")
+			}
+
 			org := state.GetCluster().Organization
 
-			Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), fmt.Sprintf("%s-cert-manager", state.GetCluster().Name), org.GetNamespace())).
-				WithTimeout(appReadyTimeout).
-				WithPolling(appReadyInterval).
-				Should(BeTrue())
+			if certManagerSupported {
+				Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), fmt.Sprintf("%s-cert-manager", state.GetCluster().Name), org.GetNamespace())).
+					WithTimeout(appReadyTimeout).
+					WithPolling(appReadyInterval).
+					Should(BeTrue())
+			}
 
-			Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), fmt.Sprintf("%s-external-dns", state.GetCluster().Name), org.GetNamespace())).
-				WithTimeout(appReadyTimeout).
-				WithPolling(appReadyInterval).
-				Should(BeTrue())
+			if externalDnsSupported {
+				Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), fmt.Sprintf("%s-external-dns", state.GetCluster().Name), org.GetNamespace())).
+					WithTimeout(appReadyTimeout).
+					WithPolling(appReadyInterval).
+					Should(BeTrue())
+			}
 		})
 
 		It("should deploy aws-lb-controller-bundle", func() {
@@ -203,6 +211,10 @@ func runHelloWorldGateway(gatewayAPISupported bool) {
 		})
 
 		It("certificate in envoy-gateway-system should be ready", func() {
+			if !certManagerSupported {
+				Skip("cert-manager is not supported")
+			}
+
 			wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -337,6 +349,10 @@ func runHelloWorldGateway(gatewayAPISupported bool) {
 		})
 
 		It("hello world app responds successfully", func() {
+			if !certManagerSupported {
+				Skip("cert-manager is not supported")
+			}
+
 			httpClient := net.NewHttpClient()
 
 			Eventually(func() (string, error) {

--- a/providers/capv/on-capa/capv_test.go
+++ b/providers/capv/on-capa/capv_test.go
@@ -12,7 +12,6 @@ var _ = Describe("Common tests", func() {
 	cfg.AutoScalingSupported = false
 	// Disabled until https://github.com/giantswarm/roadmap/issues/1037
 	cfg.ExternalDnsSupported = false
-	cfg.GatewayAPISupported = false
 
 	common.Run(cfg)
 })

--- a/providers/capv/on-capa/test_data/gateway-api-bundle_values.yaml
+++ b/providers/capv/on-capa/test_data/gateway-api-bundle_values.yaml
@@ -1,0 +1,29 @@
+clusterID: {{ .ClusterName }}
+apps:
+  gatewayApiCrds:
+    enabled: true
+  envoyGateway:
+    enabled: true
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values:
+          gateways:
+            default:
+              dnsName: ingress
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                https:
+                  dnsEndpoints:
+                    enabled: false
+                  certificate:
+                    enabled: true
+                    wildcard: true
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/providers/capv/on-capa/test_data/helloworld_route_values.yaml
+++ b/providers/capv/on-capa/test_data/helloworld_route_values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: false
+route:
+  enabled: true
+  kind: HTTPRoute
+  hostnames:
+    - {{ index .ExtraValues "IngressUrl" }}
+  parentRefs:
+    - name: giantswarm-default
+      namespace: envoy-gateway-system

--- a/providers/capv/on-capz/capv_test.go
+++ b/providers/capv/on-capz/capv_test.go
@@ -12,6 +12,5 @@ var _ = Describe("Common tests", func() {
 	cfg.AutoScalingSupported = false
 	// Disabled until https://github.com/giantswarm/roadmap/issues/1037
 	cfg.ExternalDnsSupported = false
-	cfg.GatewayAPISupported = false
 	common.Run(cfg)
 })

--- a/providers/capv/on-capz/test_data/gateway-api-bundle_values.yaml
+++ b/providers/capv/on-capz/test_data/gateway-api-bundle_values.yaml
@@ -1,0 +1,29 @@
+clusterID: {{ .ClusterName }}
+apps:
+  gatewayApiCrds:
+    enabled: true
+  envoyGateway:
+    enabled: true
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values:
+          gateways:
+            default:
+              dnsName: ingress
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                https:
+                  dnsEndpoints:
+                    enabled: false
+                  certificate:
+                    enabled: true
+                    wildcard: true
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/providers/capv/on-capz/test_data/helloworld_route_values.yaml
+++ b/providers/capv/on-capz/test_data/helloworld_route_values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: false
+route:
+  enabled: true
+  kind: HTTPRoute
+  hostnames:
+    - {{ index .ExtraValues "IngressUrl" }}
+  parentRefs:
+    - name: giantswarm-default
+      namespace: envoy-gateway-system

--- a/providers/capv/standard/capv_test.go
+++ b/providers/capv/standard/capv_test.go
@@ -12,6 +12,5 @@ var _ = Describe("Common tests", func() {
 	cfg.AutoScalingSupported = false
 	// Disabled until https://github.com/giantswarm/roadmap/issues/1037
 	cfg.ExternalDnsSupported = false
-	cfg.GatewayAPISupported = false
 	common.Run(cfg)
 })

--- a/providers/capv/standard/test_data/gateway-api-bundle_values.yaml
+++ b/providers/capv/standard/test_data/gateway-api-bundle_values.yaml
@@ -1,0 +1,29 @@
+clusterID: {{ .ClusterName }}
+apps:
+  gatewayApiCrds:
+    enabled: true
+  envoyGateway:
+    enabled: true
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values:
+          gateways:
+            default:
+              dnsName: ingress
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                https:
+                  dnsEndpoints:
+                    enabled: false
+                  certificate:
+                    enabled: true
+                    wildcard: true
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/providers/capv/standard/test_data/helloworld_route_values.yaml
+++ b/providers/capv/standard/test_data/helloworld_route_values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: false
+route:
+  enabled: true
+  kind: HTTPRoute
+  hostnames:
+    - {{ index .ExtraValues "IngressUrl" }}
+  parentRefs:
+    - name: giantswarm-default
+      namespace: envoy-gateway-system

--- a/providers/capv/upgrade/capv_test.go
+++ b/providers/capv/upgrade/capv_test.go
@@ -16,6 +16,5 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 	cfg.AutoScalingSupported = false
 	// Disabled until https://github.com/giantswarm/roadmap/issues/1037
 	cfg.ExternalDnsSupported = false
-	cfg.GatewayAPISupported = false
 	common.Run(cfg)
 })

--- a/providers/capv/upgrade/test_data/gateway-api-bundle_values.yaml
+++ b/providers/capv/upgrade/test_data/gateway-api-bundle_values.yaml
@@ -1,0 +1,29 @@
+clusterID: {{ .ClusterName }}
+apps:
+  gatewayApiCrds:
+    enabled: true
+  envoyGateway:
+    enabled: true
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values:
+          gateways:
+            default:
+              dnsName: ingress
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                https:
+                  dnsEndpoints:
+                    enabled: false
+                  certificate:
+                    enabled: true
+                    wildcard: true
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/providers/capv/upgrade/test_data/helloworld_route_values.yaml
+++ b/providers/capv/upgrade/test_data/helloworld_route_values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: false
+route:
+  enabled: true
+  kind: HTTPRoute
+  hostnames:
+    - {{ index .ExtraValues "IngressUrl" }}
+  parentRefs:
+    - name: giantswarm-default
+      namespace: envoy-gateway-system

--- a/providers/capvcd/standard/capvcd_test.go
+++ b/providers/capvcd/standard/capvcd_test.go
@@ -12,6 +12,5 @@ var _ = Describe("Common tests", func() {
 	cfg.AutoScalingSupported = false
 	// Disabled until https://github.com/giantswarm/roadmap/issues/1037
 	cfg.ExternalDnsSupported = false
-	cfg.GatewayAPISupported = false
 	common.Run(cfg)
 })

--- a/providers/capvcd/standard/test_data/gateway-api-bundle_values.yaml
+++ b/providers/capvcd/standard/test_data/gateway-api-bundle_values.yaml
@@ -1,0 +1,29 @@
+clusterID: {{ .ClusterName }}
+apps:
+  gatewayApiCrds:
+    enabled: true
+  envoyGateway:
+    enabled: true
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values:
+          gateways:
+            default:
+              dnsName: ingress
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                https:
+                  dnsEndpoints:
+                    enabled: false
+                  certificate:
+                    enabled: true
+                    wildcard: true
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/providers/capvcd/standard/test_data/helloworld_route_values.yaml
+++ b/providers/capvcd/standard/test_data/helloworld_route_values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: false
+route:
+  enabled: true
+  kind: HTTPRoute
+  hostnames:
+    - {{ index .ExtraValues "IngressUrl" }}
+  parentRefs:
+    - name: giantswarm-default
+      namespace: envoy-gateway-system

--- a/providers/capvcd/upgrade/capvcd_test.go
+++ b/providers/capvcd/upgrade/capvcd_test.go
@@ -30,6 +30,5 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 	ccfg.AutoScalingSupported = false
 	// Disabled until https://github.com/giantswarm/roadmap/issues/1037
 	ccfg.ExternalDnsSupported = false
-	ccfg.GatewayAPISupported = false
 	common.Run(ccfg)
 })

--- a/providers/capvcd/upgrade/test_data/gateway-api-bundle_values.yaml
+++ b/providers/capvcd/upgrade/test_data/gateway-api-bundle_values.yaml
@@ -1,0 +1,29 @@
+clusterID: {{ .ClusterName }}
+apps:
+  gatewayApiCrds:
+    enabled: true
+  envoyGateway:
+    enabled: true
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values:
+          gateways:
+            default:
+              dnsName: ingress
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                https:
+                  dnsEndpoints:
+                    enabled: false
+                  certificate:
+                    enabled: true
+                    wildcard: true
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/providers/capvcd/upgrade/test_data/helloworld_route_values.yaml
+++ b/providers/capvcd/upgrade/test_data/helloworld_route_values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: false
+route:
+  enabled: true
+  kind: HTTPRoute
+  hostnames:
+    - {{ index .ExtraValues "IngressUrl" }}
+  parentRefs:
+    - name: giantswarm-default
+      namespace: envoy-gateway-system

--- a/providers/capz/private/capz_test.go
+++ b/providers/capz/private/capz_test.go
@@ -10,8 +10,5 @@ var _ = Describe("Common tests", func() {
 	cfg := common.NewTestConfigWithDefaults()
 	// Disabled until https://github.com/giantswarm/roadmap/issues/2693
 	cfg.AutoScalingSupported = false
-	// Disabled until wildcard ingress support is added
-	cfg.ExternalDnsSupported = false
-	cfg.GatewayAPISupported = false
 	common.Run(cfg)
 })

--- a/providers/capz/private/test_data/cluster_values.yaml
+++ b/providers/capz/private/test_data/cluster_values.yaml
@@ -1,1 +1,5 @@
 # Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
+global:
+  connectivity:
+    certManager:
+      useDnsChallenges: true

--- a/providers/capz/private/test_data/gateway-api-bundle_values.yaml
+++ b/providers/capz/private/test_data/gateway-api-bundle_values.yaml
@@ -1,0 +1,29 @@
+clusterID: {{ .ClusterName }}
+apps:
+  gatewayApiCrds:
+    enabled: true
+  envoyGateway:
+    enabled: true
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values:
+          gateways:
+            default:
+              dnsName: ingress
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                https:
+                  dnsEndpoints:
+                    enabled: false
+                  certificate:
+                    enabled: true
+                    wildcard: true
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/providers/capz/private/test_data/helloworld_route_values.yaml
+++ b/providers/capz/private/test_data/helloworld_route_values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: false
+route:
+  enabled: true
+  kind: HTTPRoute
+  hostnames:
+    - {{ index .ExtraValues "IngressUrl" }}
+  parentRefs:
+    - name: giantswarm-default
+      namespace: envoy-gateway-system

--- a/providers/capz/standard/capz_test.go
+++ b/providers/capz/standard/capz_test.go
@@ -17,8 +17,5 @@ var _ = Describe("Common tests", func() {
 	cfg := common.NewTestConfigWithDefaults()
 	// Disabled until https://github.com/giantswarm/roadmap/issues/2693
 	cfg.AutoScalingSupported = false
-	// Disabled until wildcard ingress support is added
-	cfg.ExternalDnsSupported = false
-	cfg.GatewayAPISupported = false
 	common.Run(cfg)
 })

--- a/providers/capz/standard/test_data/cluster_values.yaml
+++ b/providers/capz/standard/test_data/cluster_values.yaml
@@ -1,1 +1,5 @@
 # Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
+global:
+  connectivity:
+    certManager:
+      useDnsChallenges: true

--- a/providers/capz/standard/test_data/gateway-api-bundle_values.yaml
+++ b/providers/capz/standard/test_data/gateway-api-bundle_values.yaml
@@ -1,0 +1,29 @@
+clusterID: {{ .ClusterName }}
+apps:
+  gatewayApiCrds:
+    enabled: true
+  envoyGateway:
+    enabled: true
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values:
+          gateways:
+            default:
+              dnsName: ingress
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                https:
+                  dnsEndpoints:
+                    enabled: false
+                  certificate:
+                    enabled: true
+                    wildcard: true
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/providers/capz/standard/test_data/helloworld_route_values.yaml
+++ b/providers/capz/standard/test_data/helloworld_route_values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: false
+route:
+  enabled: true
+  kind: HTTPRoute
+  hostnames:
+    - {{ index .ExtraValues "IngressUrl" }}
+  parentRefs:
+    - name: giantswarm-default
+      namespace: envoy-gateway-system

--- a/providers/capz/upgrade/capz_test.go
+++ b/providers/capz/upgrade/capz_test.go
@@ -14,8 +14,5 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 	cfg := common.NewTestConfigWithDefaults()
 	// Disabled until https://github.com/giantswarm/roadmap/issues/2693
 	cfg.AutoScalingSupported = false
-	// Disabled until wildcard ingress support is added
-	cfg.ExternalDnsSupported = false
-	cfg.GatewayAPISupported = false
 	common.Run(cfg)
 })

--- a/providers/capz/upgrade/test_data/cluster_values.yaml
+++ b/providers/capz/upgrade/test_data/cluster_values.yaml
@@ -1,1 +1,5 @@
 # Values provided here merge on top of the default values found in https://github.com/giantswarm/cluster-standup-teardown
+global:
+  connectivity:
+    certManager:
+      useDnsChallenges: true

--- a/providers/capz/upgrade/test_data/gateway-api-bundle_values.yaml
+++ b/providers/capz/upgrade/test_data/gateway-api-bundle_values.yaml
@@ -1,0 +1,29 @@
+clusterID: {{ .ClusterName }}
+apps:
+  gatewayApiCrds:
+    enabled: true
+  envoyGateway:
+    enabled: true
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values:
+          gateways:
+            default:
+              dnsName: ingress
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                https:
+                  dnsEndpoints:
+                    enabled: false
+                  certificate:
+                    enabled: true
+                    wildcard: true
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/providers/capz/upgrade/test_data/helloworld_route_values.yaml
+++ b/providers/capz/upgrade/test_data/helloworld_route_values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: false
+route:
+  enabled: true
+  kind: HTTPRoute
+  hostnames:
+    - {{ index .ExtraValues "IngressUrl" }}
+  parentRefs:
+    - name: giantswarm-default
+      namespace: envoy-gateway-system

--- a/providers/eks/standard/eks_test.go
+++ b/providers/eks/standard/eks_test.go
@@ -16,6 +16,5 @@ var _ = Describe("Common tests", func() {
 	cfg.ExternalDnsSupported = false
 	cfg.AutoScalingSupported = false
 	cfg.CertManagerSupported = false
-	cfg.GatewayAPISupported = false
 	common.Run(cfg)
 })

--- a/providers/eks/standard/test_data/gateway-api-bundle_values.yaml
+++ b/providers/eks/standard/test_data/gateway-api-bundle_values.yaml
@@ -1,0 +1,29 @@
+clusterID: {{ .ClusterName }}
+apps:
+  gatewayApiCrds:
+    enabled: true
+  envoyGateway:
+    enabled: true
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values:
+          gateways:
+            default:
+              dnsName: ingress
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                https:
+                  dnsEndpoints:
+                    enabled: false
+                  certificate:
+                    enabled: true
+                    wildcard: true
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/providers/eks/standard/test_data/helloworld_route_values.yaml
+++ b/providers/eks/standard/test_data/helloworld_route_values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: false
+route:
+  enabled: true
+  kind: HTTPRoute
+  hostnames:
+    - {{ index .ExtraValues "IngressUrl" }}
+  parentRefs:
+    - name: giantswarm-default
+      namespace: envoy-gateway-system

--- a/providers/eks/upgrade/eks_test.go
+++ b/providers/eks/upgrade/eks_test.go
@@ -25,6 +25,5 @@ var _ = Describe("Basic upgrade test", Ordered, func() {
 	ccfg.ExternalDnsSupported = false
 	ccfg.AutoScalingSupported = false
 	ccfg.CertManagerSupported = false
-	ccfg.GatewayAPISupported = false
 	common.Run(ccfg)
 })

--- a/providers/eks/upgrade/test_data/gateway-api-bundle_values.yaml
+++ b/providers/eks/upgrade/test_data/gateway-api-bundle_values.yaml
@@ -1,0 +1,29 @@
+clusterID: {{ .ClusterName }}
+apps:
+  gatewayApiCrds:
+    enabled: true
+  envoyGateway:
+    enabled: true
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values:
+          gateways:
+            default:
+              dnsName: ingress
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                https:
+                  dnsEndpoints:
+                    enabled: false
+                  certificate:
+                    enabled: true
+                    wildcard: true
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/providers/eks/upgrade/test_data/helloworld_route_values.yaml
+++ b/providers/eks/upgrade/test_data/helloworld_route_values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: false
+route:
+  enabled: true
+  kind: HTTPRoute
+  hostnames:
+    - {{ index .ExtraValues "IngressUrl" }}
+  parentRefs:
+    - name: giantswarm-default
+      namespace: envoy-gateway-system


### PR DESCRIPTION
## Summary

- Adds a new `hello world via gateway api` e2e test (gateway-api-bundle + hello-world via HTTPRoute) initially wired to CAPA suites
- Extends the test to capv, capz, capvcd, and EKS — provider-specific steps (external-dns check, certificate readiness, HTTP connectivity) skip when the capability is absent
- capz gains external DNS support; `capa/private` remains excluded
- Adds `gateway-api-bundle_values.yaml` and `helloworld_route_values.yaml` test data for all newly-enabled suites

## Test plan

- [ ] Verify capv/standard pipeline: external-dns step skipped, DNS + HTTPRoute + HTTP steps run
- [ ] Verify capz/standard pipeline: full test runs including DNS and HTTP
- [ ] Verify eks/standard pipeline: cert-manager and HTTP steps skipped, gateway + HTTPRoute steps run
- [ ] `go build ./...` passes (already verified locally)