### PR TITLE
revert: ARM/Graviton node pool from CAPA standard suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Revert the ARM/Graviton node pool and the `ARMNodePoolEnabled` suite flag added in v7.2.0 (#1040). The static `architecture` / `instanceType` fields on the ASG nodepool require cluster-aws 8.5.0+, but cluster-test-suites is always pulled at `latest` by `/run release-test-suites`, so any release PR using a cluster-aws version older than 8.5.0 (e.g. release v34.x.x lines) fails Helm schema validation up front (example: giantswarm/releases#2315). Reverting until the ARM additions can be gated on the release version under test.
+
 ## [7.2.0] - 2026-05-27
 
 ### Added

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -3,12 +3,9 @@ package common
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	cr "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -25,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"    //nolint:staticcheck
 )
 
-func runBasic(cfg *TestConfig) {
+func runBasic() {
 	Context("basic", func() {
 		var wcClient *client.Client
 
@@ -156,7 +153,7 @@ func runBasic(cfg *TestConfig) {
 		It("has all of its Pods in the Running state", func() {
 			Eventually(
 				wait.ConsistentWaitCondition(
-					AreAllPodsInSuccessfulPhaseWithFilter(state.GetContext(), wcClient, armExcludedPodLabels(cfg)),
+					wait.AreAllPodsInSuccessfulPhase(state.GetContext(), wcClient),
 					10,
 					time.Second,
 				)).
@@ -169,13 +166,11 @@ func runBasic(cfg *TestConfig) {
 		})
 
 		It("doesn't have restarting pods", func() {
-			// Excluding cluster-autoscaler as we have a specific test case for ensuring it is functioning
-			// Excluding karpenter because it's deployed using a HelmRelease and its pods run on the control plane. Because of this the pod is scheduled pretty early in the cluster creation process.
-			// Meanwhile, IRSA resources are getting created, but it takes a while. karpenter uses IRSA and can't run until IRSA is ready. Eventually, IRSA is ready, and the pod works normally.
-			excludedAppNames := []string{"cluster-autoscaler-app", "karpenter"}
-			excludedAppNames = append(excludedAppNames, armExcludedAppNames(cfg)...)
 			filterLabels := []string{
-				fmt.Sprintf("app.kubernetes.io/name notin (%s)", strings.Join(excludedAppNames, ", ")),
+				// Excluding cluster-autoscaler as we have a specific test case for ensuring it is functioning
+				// Excluding karpenter because it's deployed using a HelmRelease and its pods run on the control plane. Because of this the pod is scheduled pretty early in the cluster creation process.
+				// Meanwhile, IRSA resources are getting created, but it takes a while. karpenter uses IRSA and can't run until IRSA is ready. Eventually, IRSA is ready, and the pod works normally.
+				"app.kubernetes.io/name notin (cluster-autoscaler-app, karpenter)",
 			}
 
 			Eventually(
@@ -220,66 +215,6 @@ func runBasic(cfg *TestConfig) {
 				Should(Succeed())
 		})
 	})
-}
-
-// armExcludedAppNames returns the `app.kubernetes.io/name` values to exclude from pod
-// health checks when an arm64 node pool is present. The released net-exporter and
-// cert-exporter app versions aren't multi-arch yet, so their DaemonSet pods crashloop on
-// arm64 nodes. cluster-test-suites always pulls the latest release, which lags the fixed
-// app versions, so exclude them until those versions ship.
-//
-// TODO(arm64): temporary. Remove this exclusion (and the ARMNodePoolEnabled plumbing)
-// once release v35 ships the multi-arch net-exporter and cert-exporter versions.
-// See: https://github.com/giantswarm/roadmap/issues/4302
-func armExcludedAppNames(cfg *TestConfig) []string {
-	if !cfg.ARMNodePoolEnabled {
-		return nil
-	}
-	// net-exporter pods use `app.kubernetes.io/name: net-exporter`; cert-exporter's
-	// DaemonSet pods use `app.kubernetes.io/name: cert-exporter-daemonset`.
-	return []string{"net-exporter", "cert-exporter-daemonset"}
-}
-
-// armExcludedPodLabels returns label selectors filtering out the arm64-incompatible apps,
-// or an empty slice when there's nothing to exclude (so checks behave as before).
-func armExcludedPodLabels(cfg *TestConfig) []string {
-	names := armExcludedAppNames(cfg)
-	if len(names) == 0 {
-		return nil
-	}
-	return []string{fmt.Sprintf("app.kubernetes.io/name notin (%s)", strings.Join(names, ", "))}
-}
-
-// AreAllPodsInSuccessfulPhaseWithFilter checks that all Pods (minus those matched by the
-// exclusion label selectors) are in a running or completed phase. It mirrors
-// wait.AreAllPodsInSuccessfulPhase, which has no filtered variant upstream.
-func AreAllPodsInSuccessfulPhaseWithFilter(ctx context.Context, wcClient *client.Client, filterLabels []string) wait.WaitCondition {
-	return func() (bool, error) {
-		podList := &corev1.PodList{}
-		podListOptions := []cr.ListOption{}
-		for _, filter := range filterLabels {
-			parsedLabel, err := labels.Parse(filter)
-			if err != nil {
-				logger.Log("Failed to parse label '%s', skipping...", filter)
-				continue
-			}
-			podListOptions = append(podListOptions, &cr.ListOptions{LabelSelector: parsedLabel})
-		}
-		if err := wcClient.List(ctx, podList, podListOptions...); err != nil {
-			return false, err
-		}
-
-		for _, pod := range podList.Items {
-			phase := pod.Status.Phase
-			if phase != corev1.PodRunning && phase != corev1.PodSucceeded {
-				logger.Log("pod %s/%s in %s phase", pod.Namespace, pod.Name, phase)
-				return false, fmt.Errorf("pod %s/%s in %s phase", pod.Namespace, pod.Name, phase)
-			}
-		}
-
-		logger.Log("All (%d) pods currently in a running or completed state", len(podList.Items))
-		return true, nil
-	}
 }
 
 func CheckWorkerNodesReady(ctx context.Context, wcClient *client.Client, values *application.ClusterValues) func() error {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -11,7 +11,6 @@ type TestConfig struct {
 	SecurityBundleInstalled      bool
 	GatewayAPISupported          bool
 	IngressNginxSupported        bool
-	ARMNodePoolEnabled           bool
 }
 
 func NewTestConfigWithDefaults() *TestConfig {
@@ -26,13 +25,12 @@ func NewTestConfigWithDefaults() *TestConfig {
 		SecurityBundleInstalled:      true,
 		GatewayAPISupported:          true,
 		IngressNginxSupported:        false,
-		ARMNodePoolEnabled:           false,
 	}
 }
 
 func Run(cfg *TestConfig) {
 	RunApps(cfg)
-	runBasic(cfg)
+	runBasic()
 	runCertManager(cfg.CertManagerSupported)
 	runDNS(cfg.BastionSupported)
 	runMetrics(cfg)

--- a/providers/capa/standard/capa_test.go
+++ b/providers/capa/standard/capa_test.go
@@ -17,12 +17,7 @@ var _ = Describe("Common tests", func() {
 		state.SetTestTimeout(timeout.DeployApps, time.Minute*30)
 	})
 
-	cfg := common.NewTestConfigWithDefaults()
-	// This suite runs an arm64 node pool. net-exporter and cert-exporter aren't multi-arch
-	// in the currently-released app versions, so exclude their pods from the health checks.
-	// TODO(arm64): remove once release v35 ships the multi-arch versions. https://github.com/giantswarm/roadmap/issues/4302
-	cfg.ARMNodePoolEnabled = true
-	common.Run(cfg)
+	common.Run(common.NewTestConfigWithDefaults())
 
 	// ECR Credential Provider specific tests
 	ecr.Run()

--- a/providers/capa/standard/test_data/cluster_values.yaml
+++ b/providers/capa/standard/test_data/cluster_values.yaml
@@ -9,22 +9,10 @@ global:
   # testing both node provisioning models in a single run — which also reflects how customers
   # run in production (mixed ASG + Karpenter pools).
   # See: https://github.com/giantswarm/roadmap/issues/4249
-  #
-  # Additionally, exercise ARM/Graviton support with an ASG-based arm64 pool (np-arm64).
-  # The pool is tainted so amd64-only workloads from the suite don't land on arm nodes.
   nodePools:
     nodepool-0:
       minSize: 1
       maxSize: 1
-    np-arm64:
-      architecture: arm64
-      instanceType: m7g.xlarge
-      minSize: 1
-      maxSize: 1
-      customNodeTaints:
-        - effect: NoSchedule
-          key: kubernetes.io/arch
-          value: arm64
     np-karpntr:
       type: karpenter
       rootVolumeSizeGB: 15


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4302

Reverts #1040 (the ARM/Graviton node pool added to the CAPA standard suite).

The static `architecture` / `instanceType` fields on the new ASG nodepool require cluster-aws 8.5.0+, but cluster-test-suites is always pulled at `latest` by `/run release-test-suites`. Any release PR running on a cluster-aws version older than 8.5.0 (e.g. the release v34.x.x lines) now fails Helm schema validation up front — example: https://github.com/giantswarm/releases/pull/2315.

The `ARMNodePoolEnabled` suite flag (which excludes `net-exporter` and `cert-exporter-daemonset` from the pod health checks) is reverted alongside, since without an ARM node those exporters land only on amd64 and there's nothing to skip.

Reverting until the ARM additions can be gated on the release version under test (>= v35.0.0). The fixed app images are already merged:
- net-exporter: https://github.com/giantswarm/net-exporter/pull/544
- cert-exporter: https://github.com/giantswarm/cert-exporter/pull/564