### PR TITLE
build: cross-compile multi-arch image instead of emulating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dockerfile: cross-compile instead of emulating for multi-arch builds.
 - Gateway e2e: verify child apps (`gateway-api-crds`, `envoy-gateway`, `gateway-api-config`) are ready after the bundle HelmRelease deploys.
 - Gateway e2e: attach `CertificatesNotReady` and `ExternalDNSIssues` failure handlers to certificate and DNS steps for better failure diagnostics.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM golang:1.26 AS build-tests
+# Pin the build stage to the host platform so its RUN steps never run under
+# QEMU emulation. Cross-compilation is driven by TARGETOS/TARGETARCH instead.
+FROM --platform=$BUILDPLATFORM golang:1.26 AS build-tests
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
+# ginkgo here runs natively (host arch) to orchestrate the build.
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
 ADD go.mod go.sum ./
@@ -10,17 +16,22 @@ RUN go mod download
 
 ADD . .
 
-RUN ginkgo build --skip-package /X -r ./
+# GOOS/GOARCH make the underlying `go test -c` cross-compile the .test binaries
+# for the target architecture, without emulating ginkgo itself.
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} ginkgo build --skip-package /X -r ./
+
+# Cross-build the ginkgo runner that ships in the final image (must be target arch).
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/ginkgo github.com/onsi/ginkgo/v2/ginkgo
 
 FROM debian:bookworm-slim
 
 WORKDIR /app
 
-RUN apt-get update \
-  && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
+# Copy the CA bundle from the build stage instead of `apt-get install`, so the
+# target stage has no RUN step and is never emulated.
+COPY --from=build-tests /etc/ssl/certs /etc/ssl/certs
 
 COPY --from=build-tests /app /app
-COPY --from=build-tests /go/bin/ginkgo /usr/local/bin/ginkgo
+COPY --from=build-tests /out/ginkgo /usr/local/bin/ginkgo
 
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
## What

Make the Docker build cross-compile for the target architecture instead of running build steps under QEMU emulation, conforming to the [architect-orb multi-arch Dockerfiles guide](https://github.com/giantswarm/architect-orb/blob/main/docs/multi-arch-dockerfiles.md).

## Why

The guide's "good" pattern (Pattern B) is to pin build stages to the host platform (`FROM --platform=$BUILDPLATFORM`) and cross-compile via `GOOS`/`GOARCH`, and to avoid `RUN` steps in target-platform stages (they run under QEMU, "5–20× slower"). The previous `Dockerfile` did neither:

- The `build-tests` stage was not pinned, so under a multi-arch `buildx` build the whole stage (`go mod download`, `ginkgo build -r`) emulated for the non-host arch.
- The runtime stage ran `apt-get install ca-certificates`, also emulated.

## Changes

- Pin the build stage to `FROM --platform=$BUILDPLATFORM` with `ARG TARGETOS/TARGETARCH`.
- Run `ginkgo build` natively while `GOOS/GOARCH` cross-compile the `.test` binaries; cross-build the shipped `ginkgo` runner separately for the target arch.
- Replace the runtime `apt-get install ca-certificates` with a `COPY` of the CA bundle from the build stage, so no stage has an emulated `RUN`.

## Verification

Cross-built `linux/arm64` on an `amd64` host with `docker buildx` — the build stage ran natively (no QEMU) and completed successfully.