### PR TITLE
fix(capa/upgrade): Pass organization as extra value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CAPA/Upgrade: Pass organization as extra value.
+
 ## [7.2.0] - 2026-06-16
 
 ### Added

--- a/internal/common/hello_gateway.go
+++ b/internal/common/hello_gateway.go
@@ -279,7 +279,7 @@ func runHelloWorldGateway(gatewayAPISupported bool) {
 				WithClusterName(clusterName).
 				WithValuesFile("./test_data/helloworld_route_values.yaml", &helmrelease.TemplateValues{
 					ClusterName: clusterName,
-					ExtraValues: map[string]string{"IngressUrl": helloWorldHost},
+					ExtraValues: map[string]string{"Organization": org.Name, "IngressUrl": helloWorldHost},
 				})
 			Expect(err).To(BeNil())
 			helloHelmRelease, err = hrBuilder.Build()

--- a/providers/capa/upgrade/test_data/helloworld_route_values.yaml
+++ b/providers/capa/upgrade/test_data/helloworld_route_values.yaml
@@ -1,5 +1,5 @@
 clusterName: {{ .ClusterName }}
-organization: {{ .Organization }}
+organization: {{ index .ExtraValues "Organization" }}
 ingress:
   enabled: false
 route:


### PR DESCRIPTION
This was causing CAPA Upgrade tests to fail: https://tekton.ci.giantswarm.io/#/namespaces/tekton-pipelines/pipelineruns/pr-releases-2215-releases-test-suitesnrg6t.

Sadly the `TemplateValues` struct does not contain a `Organization`, so we have to pass it as `ExtraValues`.

```
 Basic upgrade test hello world via gateway api should deploy hello-world app with HTTPRoute
 /app/internal/common/hello_gateway.go:260
 I0618 11:16:00.493292      46 warning_handler.go:64] "v1beta2 OCIRepository is deprecated, upgrade to v1"
   [FAILED] in [It] - /app/internal/common/hello_gateway.go:284 @ 06/18/26 11:16:00.494
 • [FAILED] [0.274 seconds]
 Basic upgrade test hello world via gateway api [It] should deploy hello-world app with HTTPRoute
 /app/internal/common/hello_gateway.go:260

   [FAILED] Expected
       <*fmt.wrapError | 0x32af7534d080>: 
       executing values template ./test_data/helloworld_route_values.yaml: template: values:2:17: executing "values" at <.Organization>: can't evaluate field Organization in type *helmrelease.TemplateValues
       {
           msg: "executing values template ./test_data/helloworld_route_values.yaml: template: values:2:17: executing \"values\" at <.Organization>: can't evaluate field Organization in type *helmrelease.TemplateValues",
           err: <template.ExecError>{
               Name: "values",
               Err: <*errors.errorString | 0x32af759ef110>{
                   s: "template: values:2:17: executing \"values\" at <.Organization>: can't evaluate field Organization in type *helmrelease.TemplateValues",
               },
           },
       }
   to be nil
   In [It] at: /app/internal/common/hello_gateway.go:284 @ 06/18/26 11:16:00.494
```